### PR TITLE
Add CDK standards for removal policy, log retention, and ARN handling

### DIFF
--- a/.claude/agents/jeff-agent-aws-infrastructure-reviewer.md
+++ b/.claude/agents/jeff-agent-aws-infrastructure-reviewer.md
@@ -46,13 +46,15 @@ You are a principal software engineer. You are an AWS Certified Solution Archite
 - [ ] Each construct in its own file
 - [ ] Using `.env` for configuration (not hardcoded)
 - [ ] `.env.example` provided with sample values
+- [ ] No hardcoded AWS ARNs or account IDs in source; loaded via env vars or Secrets Manager/SSM
+- [ ] All resources have `removalPolicy: RemovalPolicy.DESTROY` set explicitly
 
 ### 3. Cost Optimization
 
 - [ ] Budget alarms configured
 - [ ] DynamoDB using on-demand or appropriate provisioned capacity
 - [ ] Lambda memory settings optimized
-- [ ] CloudWatch log retention periods set (not unlimited)
+- [ ] CloudWatch log retention periods set to 5 days (never unlimited)
 - [ ] API Gateway throttling configured
 - [ ] No oversized resources (RDS instances, Lambda memory, etc.)
 - [ ] Tags applied for cost tracking and grouping
@@ -62,7 +64,7 @@ You are a principal software engineer. You are an AWS Certified Solution Archite
 
 - [ ] CloudWatch alarms for critical metrics
 - [ ] Lambda functions log to CloudWatch LogGroups
-- [ ] LogGroups have retention periods set
+- [ ] LogGroups have retention set to 5 days (`RetentionDays.FIVE_DAYS`)
 - [ ] Alarms for error rates, latencies, throttling
 - [ ] AWS X-Ray enabled only when needed (not by default)
 - [ ] Meaningful log messages and structured logging
@@ -131,13 +133,15 @@ You are a principal software engineer. You are an AWS Certified Solution Archite
 
 - IAM policies with `*` for actions or resources without justification
 - Hardcoded secrets or credentials
+- Hardcoded AWS ARNs or account IDs in source code (must be loaded via env vars or Secrets Manager/SSM)
 - Missing encryption at rest
 - Public S3 buckets without explicit intent
 - No CloudWatch alarms for critical services
 - Lambda functions without timeout or memory settings
 - Missing point-in-time recovery for DynamoDB
 - No rate limiting on API Gateway
-- CloudWatch logs without retention
+- CloudWatch LogGroups without retention, or retention longer than 5 days
+- Resources missing `removalPolicy: RemovalPolicy.DESTROY`
 - `while True:` loops in Lambda handler code (use `for` loops with a configurable max, default 1000)
 
 ### Suggestions (Should Fix)

--- a/.claude/agents/jeff-agent-aws-solution-architect.md
+++ b/.claude/agents/jeff-agent-aws-solution-architect.md
@@ -49,6 +49,12 @@ You are a principal software engineer. You are an AWS Certified Solution Archite
 - Optimize all Lambda code for minimal cold starts
 - Always use Graviton unless not possible
 
+## CDK Standards
+
+- Always set `removalPolicy: cdk.RemovalPolicy.DESTROY` on all resources by default
+- Always set CloudWatch LogGroup retention to 5 days (`logs.RetentionDays.FIVE_DAYS`); never leave retention unlimited
+- Never hardcode AWS ARNs or account IDs in source code; always load them from environment variables or Secrets Manager/SSM
+
 ## Lambda Coding Standards
 
 - Never use `while True:` loops in Lambda handlers; always use a `for` loop with a configurable max iteration count (default 1000) to prevent runaway execution and ensure predictable timeouts

--- a/.claude/skills/jeff-skill-aws-cdk-project/SKILL.md
+++ b/.claude/skills/jeff-skill-aws-cdk-project/SKILL.md
@@ -43,6 +43,8 @@ Before proceeding:
 
 These must be used for common build/deploy arguments instead of hardcoding in the code (e.g., API Gateway rate limits, AWS account, alarm periods, allowed Cognito origins, etc.).
 
+**Never hardcode AWS ARNs or account IDs in source.** Always load them from environment variables via `.env` or from Secrets Manager/SSM.
+
 ### Unit tests requirements
 
 - Use vitest for unit tests
@@ -51,9 +53,11 @@ These must be used for common build/deploy arguments instead of hardcoding in th
 - Tests must assert configuration expectations, such as:
   - Alarms configured for all infrastructure
   - API Gateway always has a rate limit enforced
-  - CloudWatch log LogGroups always has a retention period set
+  - CloudWatch log LogGroups always have retention set to exactly 5 days (`RetentionDays.FIVE_DAYS`)
   - Lambdas always have memory and timeout explicitly set
   - DynamoDB tables always have point-in-time recovery enabled
+  - All resources have `removalPolicy: RemovalPolicy.DESTROY`
+  - No hardcoded AWS ARNs or account IDs anywhere in source
   - IAM roles have least-privilege permissions and no \* references to refer to actions or resources (unless that's the best practice way for a specific service or permission)
   - etc...
 
@@ -225,6 +229,46 @@ export class DynamoDBConstruct extends Construct {
 ```
 
 It's ok to combine multiple Lambda functions in the same Lambda construct file if they are closely related in business purpose. Same idea applies to other resources (multiple DynamoDB tables can all live in the same construct file if they are closely related in business purpose). But typically do not mix resources in a single construct file (like mixing Lambda and DynamoDB resources in the same construct file).
+
+## Required CDK Defaults
+
+Every CDK construct must follow these non-negotiable defaults:
+
+### Removal Policy
+
+Always set `removalPolicy: cdk.RemovalPolicy.DESTROY` on all resources. This prevents orphaned resources in dev/test environments:
+
+```typescript
+const table = new dynamodb.Table(this, 'MyTable', {
+  partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
+  removalPolicy: cdk.RemovalPolicy.DESTROY,
+});
+```
+
+### CloudWatch Log Retention
+
+Always set log retention to 5 days. Never leave it unlimited:
+
+```typescript
+import * as logs from 'aws-cdk-lib/aws-logs';
+
+const logGroup = new logs.LogGroup(this, 'MyLogGroup', {
+  retention: logs.RetentionDays.FIVE_DAYS,
+  removalPolicy: cdk.RemovalPolicy.DESTROY,
+});
+```
+
+### No Hardcoded ARNs or Account IDs
+
+Never hardcode AWS ARNs, account IDs, or region-specific identifiers in source. Load them from `.env` via `process.env`:
+
+```typescript
+// BAD — never do this
+const roleArn = 'arn:aws:iam::123456789012:role/MyRole';
+
+// GOOD — load from environment
+const roleArn = process.env.MY_ROLE_ARN!;
+```
 
 ## GitHub Actions
 


### PR DESCRIPTION
## Summary
This PR establishes and documents mandatory CDK best practices across all skill and agent documentation to ensure consistent, secure, and cost-optimized infrastructure-as-code patterns.

## Key Changes

- **Removal Policy Enforcement**: Added requirement that all CDK resources must explicitly set `removalPolicy: cdk.RemovalPolicy.DESTROY` to prevent orphaned resources in dev/test environments
- **CloudWatch Log Retention**: Standardized log retention to exactly 5 days (`RetentionDays.FIVE_DAYS`) across all LogGroups, with explicit prohibition against unlimited retention
- **ARN and Account ID Security**: Added strict requirement to never hardcode AWS ARNs or account IDs in source code; must load from environment variables or Secrets Manager/SSM
- **Updated Test Requirements**: Enhanced unit test assertions to verify removal policies, log retention settings, and absence of hardcoded identifiers
- **Agent Checklists**: Updated infrastructure reviewer and solution architect agent guidelines to include these standards in their validation and suggestion criteria

## Implementation Details

- Added new "Required CDK Defaults" section to skill documentation with code examples for proper patterns
- Updated cost optimization and security checklist items to reflect the 5-day log retention standard
- Added explicit security red flags for hardcoded ARNs/account IDs and missing removal policies
- Ensured consistency across all three documentation files (skill, reviewer agent, architect agent)

These changes establish non-negotiable defaults that will be enforced during code review and testing phases.

https://claude.ai/code/session_014AdWwXfDmtZQuGZjqQdC28