### PR TITLE
Add PascalCase naming convention requirement for CDK constructs

### DIFF
--- a/.claude/agents/jeff-agent-aws-infrastructure-reviewer.md
+++ b/.claude/agents/jeff-agent-aws-infrastructure-reviewer.md
@@ -108,7 +108,7 @@ You are a principal software engineer. You are an AWS Certified Solution Archite
 
 ### 9. Naming & Tagging
 
-- [ ] All CDK construct IDs and resource logical IDs use PascalCase (camelCase starting with capital letter)
+- [ ] All CDK construct IDs and resource logical IDs use PascalCase
 - [ ] Resources have meaningful names
 - [ ] Tags for application, environment, owner
 - [ ] Consistent naming conventions

--- a/.claude/agents/jeff-agent-aws-infrastructure-reviewer.md
+++ b/.claude/agents/jeff-agent-aws-infrastructure-reviewer.md
@@ -108,6 +108,7 @@ You are a principal software engineer. You are an AWS Certified Solution Archite
 
 ### 9. Naming & Tagging
 
+- [ ] All CDK construct IDs and resource logical IDs use PascalCase (camelCase starting with capital letter)
 - [ ] Resources have meaningful names
 - [ ] Tags for application, environment, owner
 - [ ] Consistent naming conventions
@@ -146,6 +147,7 @@ You are a principal software engineer. You are an AWS Certified Solution Archite
 
 ### Suggestions (Should Fix)
 
+- CDK construct IDs or resource logical IDs not using PascalCase (e.g. `'my-table'`, `'apiLogs'`, `'process_order'`)
 - No budget alarms configured
 - Missing tags for cost allocation
 - Not using Graviton for Lambda
@@ -158,7 +160,7 @@ You are a principal software engineer. You are an AWS Certified Solution Archite
 
 - Additional alarms for secondary metrics
 - More granular IAM policies
-- Better construct naming
+- More descriptive construct names
 - Additional tags for organization
 
 ## Feedback Format

--- a/.claude/agents/jeff-agent-aws-solution-architect.md
+++ b/.claude/agents/jeff-agent-aws-solution-architect.md
@@ -51,6 +51,7 @@ You are a principal software engineer. You are an AWS Certified Solution Archite
 
 ## CDK Standards
 
+- All CDK construct IDs and resource logical IDs must use PascalCase (camelCase starting with a capital letter), e.g. `'UsersTable'`, `'ApiLogGroup'`, `'ProcessOrderFunction'`
 - Always set `removalPolicy: cdk.RemovalPolicy.DESTROY` on all resources by default
 - Always set CloudWatch LogGroup retention to 5 days (`logs.RetentionDays.FIVE_DAYS`); never leave retention unlimited
 - Never hardcode AWS ARNs or account IDs in source code; always load them from environment variables or Secrets Manager/SSM

--- a/.claude/agents/jeff-agent-aws-solution-architect.md
+++ b/.claude/agents/jeff-agent-aws-solution-architect.md
@@ -51,7 +51,7 @@ You are a principal software engineer. You are an AWS Certified Solution Archite
 
 ## CDK Standards
 
-- All CDK construct IDs and resource logical IDs must use PascalCase (camelCase starting with a capital letter), e.g. `'UsersTable'`, `'ApiLogGroup'`, `'ProcessOrderFunction'`
+- All CDK construct IDs and resource logical IDs must use PascalCase, e.g. `'UsersTable'`, `'ApiLogGroup'`, `'ProcessOrderFunction'`
 - Always set `removalPolicy: cdk.RemovalPolicy.DESTROY` on all resources by default
 - Always set CloudWatch LogGroup retention to 5 days (`logs.RetentionDays.FIVE_DAYS`); never leave retention unlimited
 - Never hardcode AWS ARNs or account IDs in source code; always load them from environment variables or Secrets Manager/SSM

--- a/.claude/skills/jeff-skill-aws-cdk-project/SKILL.md
+++ b/.claude/skills/jeff-skill-aws-cdk-project/SKILL.md
@@ -232,7 +232,7 @@ It's ok to combine multiple Lambda functions in the same Lambda construct file i
 
 ## Naming Conventions
 
-All CDK infrastructure identifiers (construct IDs, resource logical IDs) must use PascalCase — camelCase starting with a capital letter.
+All CDK infrastructure identifiers (construct IDs, resource logical IDs) must use PascalCase.
 
 ```typescript
 // GOOD

--- a/.claude/skills/jeff-skill-aws-cdk-project/SKILL.md
+++ b/.claude/skills/jeff-skill-aws-cdk-project/SKILL.md
@@ -230,6 +230,28 @@ export class DynamoDBConstruct extends Construct {
 
 It's ok to combine multiple Lambda functions in the same Lambda construct file if they are closely related in business purpose. Same idea applies to other resources (multiple DynamoDB tables can all live in the same construct file if they are closely related in business purpose). But typically do not mix resources in a single construct file (like mixing Lambda and DynamoDB resources in the same construct file).
 
+## Naming Conventions
+
+All CDK infrastructure identifiers (construct IDs, resource logical IDs) must use PascalCase — camelCase starting with a capital letter.
+
+```typescript
+// GOOD
+new dynamodb.Table(this, 'UsersTable', { ... });
+new logs.LogGroup(this, 'ApiLogGroup', { ... });
+new lambda.Function(this, 'ProcessOrderFunction', { ... });
+new MyAppStack(app, 'MyAppStack', { ... });
+
+// BAD — lowercase, kebab-case, snake_case
+new dynamodb.Table(this, 'users-table', { ... });
+new logs.LogGroup(this, 'apiLogGroup', { ... });
+new lambda.Function(this, 'process_order_function', { ... });
+```
+
+This applies to:
+- Stack IDs passed to `new MyStack(app, 'StackId', ...)`
+- Construct IDs passed to `super(scope, 'ConstructId')` and `new SomeConstruct(this, 'ConstructId', ...)`
+- All logical resource IDs passed to AWS CDK resource constructors
+
 ## Required CDK Defaults
 
 Every CDK construct must follow these non-negotiable defaults:


### PR DESCRIPTION
## Summary
This PR establishes and documents a mandatory naming convention for AWS CDK infrastructure identifiers, requiring all construct IDs and resource logical IDs to use PascalCase (camelCase starting with a capital letter).

## Key Changes
- **SKILL.md**: Added comprehensive "Naming Conventions" section with clear examples of correct PascalCase usage and common mistakes (kebab-case, snake_case, lowercase)
- **jeff-agent-aws-infrastructure-reviewer.md**: 
  - Added PascalCase compliance check to the "Naming & Tagging" section
  - Added specific suggestion for fixing non-PascalCase construct IDs
  - Updated "Nice to Have" section to focus on descriptiveness rather than generic naming improvements
- **jeff-agent-aws-solution-architect.md**: Added explicit PascalCase requirement to CDK Standards with concrete examples

## Implementation Details
The naming convention applies to:
- Stack IDs passed to `new MyStack(app, 'StackId', ...)`
- Construct IDs passed to `super(scope, 'ConstructId')` and `new SomeConstruct(this, 'ConstructId', ...)`
- All logical resource IDs passed to AWS CDK resource constructors

Examples of correct usage: `'UsersTable'`, `'ApiLogGroup'`, `'ProcessOrderFunction'`

https://claude.ai/code/session_017fSzSyyDxic5XGqzQSKFrH