### PR TITLE
Remove model specification from agent configs and update AWS env vars

### DIFF
--- a/.claude/agents/jeff-agent-angular-code-reviewer.md
+++ b/.claude/agents/jeff-agent-angular-code-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: jeff-angular-code-reviewer
 description: Expert Angular code reviewer focusing on best practices, accessibility, performance, and Angular style guide compliance. Use for reviewing Angular code, components, and providing objective code review feedback.
-model: opus
 skills:
   - jeff-skill-install-nodejs
   - jeff-skill-install-prettier

--- a/.claude/agents/jeff-agent-angular-software-developer.md
+++ b/.claude/agents/jeff-agent-angular-software-developer.md
@@ -1,7 +1,6 @@
 ---
 name: jeff-angular-software-developer
 description: Expert Angular developer following official best practices for building scalable, maintainable applications. Use for Angular component development, architecture decisions, testing, performance optimization, and following framework conventions.
-model: opus
 skills:
   - jeff-skill-install-nodejs
   - jeff-skill-install-prettier

--- a/.claude/agents/jeff-agent-aws-solution-architect.md
+++ b/.claude/agents/jeff-agent-aws-solution-architect.md
@@ -1,7 +1,6 @@
 ---
 name: jeff-aws-solution-architect
 description: Expert AWS Certified Solution Architect - Professional. Use for system design, cdk projects, and AWS infrastructure questions.
-model: opus
 skills:
   - jeff-skill-install-nodejs
   - jeff-skill-install-prettier

--- a/.claude/agents/jeff-agent-golang-code-reviewer.md
+++ b/.claude/agents/jeff-agent-golang-code-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: jeff-golang-code-reviewer
 description: Expert Go code reviewer focusing on idiomatic Go, error handling, concurrency, and Effective Go principles. Use for reviewing Go code, pull requests, and providing objective code review feedback.
-model: opus
 skills:
   - jeff-skill-golang-project
 ---

--- a/.claude/agents/jeff-agent-golang-software-developer.md
+++ b/.claude/agents/jeff-agent-golang-software-developer.md
@@ -1,7 +1,6 @@
 ---
 name: jeff-golang-software-developer
 description: Expert Go developer following idiomatic Go and Effective Go principles. Use for Go development, testing, code review, refactoring, and debugging.
-model: opus
 skills:
   - jeff-skill-golang-project
 ---

--- a/.claude/agents/jeff-agent-python-code-reviewer.md
+++ b/.claude/agents/jeff-agent-python-code-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: jeff-python-code-reviewer
 description: Expert Python code reviewer focusing on PEP standards, security, testing, and best practices. Use for reviewing Python code, pull requests, and providing objective code review feedback.
-model: opus
 skills:
   - jeff-skill-python-project
 ---

--- a/.claude/agents/jeff-agent-python-software-developer.md
+++ b/.claude/agents/jeff-agent-python-software-developer.md
@@ -1,7 +1,6 @@
 ---
 name: jeff-python-software-developer
 description: Expert Python developer following PEP standards and modern best practices. Use for Python development, testing, code review, refactoring, and debugging.
-model: opus
 skills:
   - jeff-skill-python-project
 ---

--- a/.claude/agents/jeff-agent-typescript-code-reviewer.md
+++ b/.claude/agents/jeff-agent-typescript-code-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: jeff-typescript-code-reviewer
 description: Expert TypeScript code reviewer focusing on type safety, modern best practices, testing, and Node.js patterns. Use for reviewing TypeScript code, pull requests, and providing objective code review feedback.
-model: opus
 skills:
   - jeff-skill-install-nodejs
   - jeff-skill-install-prettier

--- a/.claude/agents/jeff-agent-typescript-software-developer.md
+++ b/.claude/agents/jeff-agent-typescript-software-developer.md
@@ -1,7 +1,6 @@
 ---
 name: jeff-typescript-software-developer
 description: Expert TypeScript developer following strict type safety and modern best practices. Use for TypeScript development (backend, CLI, libraries), testing, refactoring, and debugging.
-model: opus
 skills:
   - jeff-skill-install-nodejs
   - jeff-skill-install-prettier

--- a/.claude/skills/jeff-skill-aws-cdk-project/SKILL.md
+++ b/.claude/skills/jeff-skill-aws-cdk-project/SKILL.md
@@ -171,8 +171,8 @@ const app = new cdk.App();
 
 new MyAppStack(app, 'MyAppStack', {
   env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION,
+    account: process.env.AWS_ACCOUNT,
+    region: process.env.AWS_REGION,
     // ...other args too
   }
 });


### PR DESCRIPTION
## Summary
This PR removes the explicit `model: opus` specification from all agent configuration files and updates the AWS CDK skill to use standard AWS environment variable names.

## Key Changes
- **Agent Configurations**: Removed `model: opus` field from 8 agent definition files across multiple languages (Angular, Go, Python, TypeScript, and AWS). This allows agents to use the default model configuration instead of being pinned to a specific model.
- **AWS CDK Skill**: Updated environment variable references in the AWS CDK project skill from `CDK_DEFAULT_ACCOUNT` and `CDK_DEFAULT_REGION` to the standard AWS environment variables `AWS_ACCOUNT` and `AWS_REGION`.

## Files Modified
- `.claude/agents/` - 8 agent configuration files (Angular code reviewer/developer, Go code reviewer/developer, Python code reviewer/developer, TypeScript code reviewer/developer, AWS solution architect)
- `.claude/skills/jeff-skill-aws-cdk-project/SKILL.md` - AWS environment variable names

## Notable Details
The removal of the hardcoded model specification makes the agents more flexible and allows them to adapt to model availability and configuration changes without requiring updates to these definition files.

https://claude.ai/code/session_01AyAEbZkA7DV9YpFUjiRU7W