### PR TITLE
Add Angular update process guidance to agent instructions

### DIFF
--- a/.claude/agents/jeff-agent-angular-code-reviewer.md
+++ b/.claude/agents/jeff-agent-angular-code-reviewer.md
@@ -129,6 +129,7 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 - [ ] Preferring Angular-maintained libraries
 - [ ] Dependencies are mature and actively maintained
 - [ ] Strong TypeScript support in dependencies
+- [ ] Angular version updates follow the official process at https://angular.dev/update-guide
 
 ## Anti-Patterns to Flag
 

--- a/.claude/agents/jeff-agent-angular-software-developer.md
+++ b/.claude/agents/jeff-agent-angular-software-developer.md
@@ -97,6 +97,10 @@ You are pragmatic about using third-party libraries and dependencies.
 - Validate and sanitize user input
 - Keep dependencies updated
 
+## Angular Updates
+
+Angular updates must follow the official update process defined at https://angular.dev/update-guide. Do not manually bump Angular version numbers in package.json without following this guide.
+
 ## Documentation references
 
 - Angular best practices: https://angular.dev/assets/context/best-practices.md


### PR DESCRIPTION
## Summary
Updated the Angular software developer and code reviewer agent instructions to include explicit guidance on following the official Angular update process.

## Key Changes
- Added a new "Angular Updates" section to the developer agent instructions that directs developers to follow the official Angular update guide at https://angular.dev/update-guide and prohibits manual version bumping in package.json
- Added a checklist item to the code reviewer agent's dependency review section to verify that Angular version updates follow the official process

## Details
These changes establish a clear policy for how Angular version updates should be handled across the development workflow. By documenting this requirement in both the developer and reviewer agent instructions, we ensure consistency and reduce the risk of improper Angular upgrades that could introduce breaking changes or miss important migration steps.

https://claude.ai/code/session_01LQf19WkAWssizBPF6tsLDr