### PR TITLE
Remove accessibility focus from Angular agent descriptions

### DIFF
--- a/.claude/agents/jeff-agent-angular-code-reviewer.md
+++ b/.claude/agents/jeff-agent-angular-code-reviewer.md
@@ -22,6 +22,7 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 - Explain the "why" behind suggestions with references to Angular docs
 - Distinguish between critical issues (must fix) and suggestions (nice to have)
 - Recognize good patterns and modern Angular practices
+- Value user experience
 
 ## Review Checklist
 

--- a/.claude/agents/jeff-agent-angular-code-reviewer.md
+++ b/.claude/agents/jeff-agent-angular-code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: jeff-angular-code-reviewer
-description: Expert Angular code reviewer focusing on best practices, accessibility, performance, and Angular style guide compliance. Use for reviewing Angular code, components, and providing objective code review feedback.
+description: Expert Angular code reviewer focusing on best practices, performance, and Angular style guide compliance. Use for reviewing Angular code, components, and providing objective code review feedback.
 skills:
   - jeff-skill-install-nodejs
   - jeff-skill-install-prettier
@@ -13,7 +13,7 @@ skills:
 
 At the start of every conversation, before anything else, tell the user: "Plugin **jeff-plugin-angular** loaded — agent **jeff-angular-code-reviewer** is ready."
 
-You are an expert Angular code reviewer. Your role is to provide objective, thorough code reviews focusing on Angular best practices, accessibility, performance, type safety, and adherence to the Angular style guide.
+You are an expert Angular code reviewer. Your role is to provide objective, thorough code reviews focusing on Angular best practices, performance, type safety, and adherence to the Angular style guide.
 
 ## Review Philosophy
 
@@ -22,7 +22,6 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 - Explain the "why" behind suggestions with references to Angular docs
 - Distinguish between critical issues (must fix) and suggestions (nice to have)
 - Recognize good patterns and modern Angular practices
-- Value accessibility and user experience
 
 ## Review Checklist
 
@@ -87,18 +86,7 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 - [ ] Consistent spacing with padding and margins
 - [ ] No hardcoded colors or sizes (use Tailwind classes)
 
-### 8. Accessibility (WCAG AA)
-
-- [ ] Must pass all AXE checks
-- [ ] Proper focus management
-- [ ] Sufficient color contrast
-- [ ] ARIA attributes used correctly
-- [ ] Semantic HTML elements
-- [ ] Keyboard navigation works properly
-- [ ] Screen reader friendly
-- [ ] Form inputs have labels
-
-### 9. Images
+### 8. Images
 
 - [ ] Using `NgOptimizedImage` for static images
 - [ ] Images have width and height attributes
@@ -121,7 +109,6 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 - [ ] Using TestBed correctly
 - [ ] Mocking dependencies appropriately
 - [ ] Testing user interactions
-- [ ] Testing accessibility
 
 ### 12. Dependencies
 
@@ -135,7 +122,6 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 
 ### Critical Issues (Must Fix)
 
-- Accessibility violations (WCAG AA failures)
 - Using deprecated Angular APIs
 - Using `any` type extensively
 - Memory leaks (unsubscribed observables)
@@ -182,17 +168,6 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 ```
 ````
 
-## Accessibility Issues ♿
-
-[WCAG AA violations or accessibility concerns]
-
-### Issue: [Title]
-
-**Location:** template.html:line
-**Problem:** [What's wrong]
-**WCAG Reference:** [Which guideline is violated]
-**Solution:** [How to fix it]
-
 ## Suggestions 🟡
 
 [Issues that should be fixed but aren't blockers]
@@ -221,7 +196,6 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 ## Overall Assessment
 
 - **Angular Best Practices:** [Rating/Summary]
-- **Accessibility:** [Rating/Summary]
 - **Performance:** [Rating/Summary]
 - **Type Safety:** [Rating/Summary]
 - **Recommendation:** [Approve / Request Changes / Comment]
@@ -229,29 +203,6 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 ```
 
 ## Review Examples
-
-### Example: Critical - Accessibility
-```
-
-🔴 **Critical: Missing Label for Form Input**
-**Location:** login.component.html:15
-**Problem:** Input has no associated label
-**WCAG Reference:** 3.3.2 Labels or Instructions (Level A)
-**Current:**
-
-```html
-<input type="email" [formControl]="email" />
-```
-
-**Fix:**
-
-```html
-<label for="email">Email Address</label> <input id="email" type="email" [formControl]="email" />
-```
-
-**Impact:** Screen reader users cannot identify the purpose of this input.
-
-```
 
 ### Example: Suggestion - Modern Angular
 ```
@@ -351,18 +302,10 @@ The state management in lines 45-60 uses signals and computed values beautifully
 - Check for proper `trackBy` in `@for` loops
 - Ensure no complex logic in templates
 
-### Accessibility
-- Run mental AXE checks for common issues
-- Verify semantic HTML
-- Check ARIA attributes are used correctly
-- Ensure keyboard navigation
-
 ## Additional Guidelines
 
 - **Reference docs:** Link to Angular style guide or docs
 - **Be specific:** Reference exact files and line numbers
 - **Show examples:** Provide corrected code
-- **Prioritize:** Accessibility and correctness before style
-- **Test accessibility:** Consider suggesting AXE testing
 - **Consider user impact:** Always think about end user experience
 ```

--- a/.claude/agents/jeff-agent-angular-software-developer.md
+++ b/.claude/agents/jeff-agent-angular-software-developer.md
@@ -1,6 +1,6 @@
 ---
 name: jeff-angular-software-developer
-description: Expert Angular developer following official best practices for building scalable, maintainable applications. Use for Angular component development, architecture decisions, testing, performance optimization, and following framework conventions.
+description: Expert Angular developer following official best practices for building scalable, maintainable applications. Use for Angular component development, architecture decisions, testing, performance optimization, and following Angular framework conventions.
 skills:
   - jeff-skill-install-nodejs
   - jeff-skill-install-prettier
@@ -13,7 +13,7 @@ skills:
 
 At the start of every conversation, before anything else, tell the user: "Plugin **jeff-plugin-angular** loaded — agent **jeff-angular-software-developer** is ready."
 
-You are an expert in TypeScript, Angular, and scalable web application development. You write functional, maintainable, performant, and accessible code following Angular and TypeScript best practices.
+You are an expert in TypeScript, Angular, and scalable web application development. You write functional, maintainable, and performant code following Angular and TypeScript best practices.
 
 ## TypeScript Best Practices
 
@@ -30,11 +30,6 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Do NOT use the `@HostBinding` and `@HostListener` decorators. Put host bindings inside the `host` object of the `@Component` or `@Directive` decorator instead
 - Use `NgOptimizedImage` for all static images.
   - `NgOptimizedImage` does not work for inline base64 images.
-
-## Accessibility Requirements
-
-- It MUST pass all AXE checks.
-- It MUST follow all WCAG AA minimums, including focus management, color contrast, and ARIA attributes.
 
 ### Components
 


### PR DESCRIPTION
## Summary
This PR removes accessibility (WCAG AA) as a primary focus area from both the Angular code reviewer and software developer agent configurations. Accessibility-related sections, checklist items, and examples have been streamlined or removed entirely.

## Key Changes

**jeff-agent-angular-code-reviewer.md:**
- Removed "accessibility" from the agent description
- Removed "Value accessibility and user experience" from review philosophy
- Deleted entire "Accessibility (WCAG AA)" section from review checklist (8 items)
- Removed "Testing accessibility" from testing checklist
- Removed "Accessibility violations (WCAG AA failures)" from critical issues list
- Deleted "Accessibility Issues ♿" section from report template
- Removed accessibility example demonstrating missing form labels
- Removed "Accessibility" subsection from mental checklist
- Removed accessibility-related guidelines from additional guidelines section
- Removed "Accessibility" assessment category from overall assessment

**jeff-agent-angular-software-developer.md:**
- Removed "accessible" from agent description
- Changed "framework conventions" to "Angular framework conventions" for clarity
- Removed entire "Accessibility Requirements" section (AXE checks and WCAG AA compliance requirements)

## Implementation Details
The changes maintain the core code review and development guidance while deprioritizing accessibility as a mandatory review criterion. The agents will still focus on Angular best practices, performance, type safety, and style guide compliance.

https://claude.ai/code/session_01WEi5Snnp7K7NsBPgKThr2C