### PR TITLE
Fix skill documentation and improve cross-skill integration

### DIFF
--- a/.claude/agents/jeff-agent-angular-code-reviewer.md
+++ b/.claude/agents/jeff-agent-angular-code-reviewer.md
@@ -6,6 +6,7 @@ skills:
   - jeff-skill-install-prettier
   - jeff-skill-angular-project
   - jeff-skill-angular-aws-cognito
+  - jeff-skill-tailwind-design-system
   - jeff-skill-install-dependabot
 ---
 

--- a/.claude/agents/jeff-agent-angular-software-developer.md
+++ b/.claude/agents/jeff-agent-angular-software-developer.md
@@ -6,6 +6,7 @@ skills:
   - jeff-skill-install-prettier
   - jeff-skill-angular-project
   - jeff-skill-angular-aws-cognito
+  - jeff-skill-tailwind-design-system
   - jeff-skill-install-dependabot
 ---
 

--- a/.claude/agents/jeff-agent-tailwind-ui-ux-developer.md
+++ b/.claude/agents/jeff-agent-tailwind-ui-ux-developer.md
@@ -3,6 +3,8 @@ name: jeff-tailwind-ui-ux-developer
 description: Expert frontend developer building UI/UX with Tailwind CSS v4 design systems, design tokens, and component libraries. Use for implementing design systems, building components, or standardizing UI patterns.
 skills:
   - jeff-skill-tailwind-design-system
+  - jeff-skill-angular-project
+  - jeff-skill-angular-aws-cognito
 ---
 
 ## Startup Acknowledgment

--- a/.claude/agents/jeff-agent-tailwind-ui-ux-reviewer.md
+++ b/.claude/agents/jeff-agent-tailwind-ui-ux-reviewer.md
@@ -3,6 +3,8 @@ name: jeff-tailwind-ui-ux-reviewer
 description: Expert reviewer for Tailwind CSS v4 UI/UX implementations, design system compliance, and component quality. Use for reviewing frontend code, design token usage, and Tailwind v4 patterns.
 skills:
   - jeff-skill-tailwind-design-system
+  - jeff-skill-angular-project
+  - jeff-skill-angular-aws-cognito
 ---
 
 ## Startup Acknowledgment

--- a/.claude/skills/jeff-skill-angular-project/SKILL.md
+++ b/.claude/skills/jeff-skill-angular-project/SKILL.md
@@ -47,12 +47,10 @@ Before proceeding:
 
 ## Integration with Other Skills
 
-- **jeff-skill-error-debugging-rca**: Use when debugging errors or test failuresAngular projects or related tools
+- **jeff-skill-error-debugging-rca**: Use when debugging errors or test failures in Angular projects or related tools
+- **jeff-skill-angular-aws-cognito**: Integrate AWS Cognito authentication into the Angular app
+- **jeff-skill-tailwind-design-system**: Apply Tailwind v4 design tokens, component patterns, and theming after initial project setup
 
 ## Additional resources
 
 - Refer to the Angular documentation if you need help: https://angular.io/docs
-
-## Integration with Other Skills
-
-- **jeff-skill-angular-aws-cognito**: Angular test creation and standards reference

--- a/.claude/skills/jeff-skill-tailwind-design-system/SKILL.md
+++ b/.claude/skills/jeff-skill-tailwind-design-system/SKILL.md
@@ -180,6 +180,11 @@ Example:
 Base styles → Variants → Sizes → States → Overrides
 ```
 
+## Integration with Other Skills
+
+- **jeff-skill-angular-project**: Use to scaffold the Angular project and install Tailwind CSS before applying design system patterns from this skill
+- **jeff-skill-error-debugging-rca**: Use when debugging Tailwind configuration or CSS compilation issues
+
 ## Detailed patterns and worked examples
 
 Detailed pattern documentation lives in `references/details.md`. Read that file when the navigation tier above is insufficient.


### PR DESCRIPTION
## Summary
Updated skill documentation files to fix grammatical errors, remove duplicate sections, and establish clearer cross-skill integration references between Angular, Tailwind, and error debugging skills.

## Key Changes
- **jeff-skill-angular-project/SKILL.md**:
  - Fixed grammatical error in error-debugging-rca skill reference (added missing "in")
  - Removed duplicate "Integration with Other Skills" section
  - Clarified AWS Cognito integration reference
  - Added Tailwind design system integration reference with proper context about when to use it (after initial project setup)
  - Removed incorrect reference to "Angular test creation and standards" from Cognito skill

- **jeff-skill-tailwind-design-system/SKILL.md**:
  - Added new "Integration with Other Skills" section
  - Documented dependency on angular-project skill for initial setup
  - Added reference to error-debugging-rca skill for Tailwind-specific issues

## Notable Details
The changes establish a clearer skill dependency chain: Angular project setup → Tailwind design system application → Error debugging as needed. This helps users understand the proper sequence and context for using each skill.

https://claude.ai/code/session_01Gooov2VyddoNV3oj8gJBWC