### PR TITLE
Add Prettier formatting step to package-skills workflow

### DIFF
--- a/.github/workflows/package-skills.yml
+++ b/.github/workflows/package-skills.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 'lts/*'
 
       - name: Run Prettier
         run: npx --yes prettier --write .

--- a/.github/workflows/package-skills.yml
+++ b/.github/workflows/package-skills.yml
@@ -19,6 +19,25 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run Prettier
+        run: npx --yes prettier --write .
+
+      - name: Commit Prettier changes if any
+        run: |
+          git config --global user.email "actions@users.noreply.github.com"
+          git config --global user.name "JEFF-bot"
+          git add -A
+          if git commit -m "Apply Prettier formatting [skip-package]"; then
+            git push
+          else
+            echo "No Prettier changes to commit"
+          fi
+
       - name: Create individual skill and agent packages
         run: |
           mkdir -p zip


### PR DESCRIPTION
## Summary

Added an automated code formatting step to the `package-skills` GitHub Actions workflow to ensure all files are formatted with Prettier before packaging.

## Key Changes

- **Setup Node.js**: Added Node.js v20 setup step to enable running Prettier
- **Run Prettier**: Execute Prettier with `--write` flag to format all files in the repository
- **Auto-commit formatting**: Automatically commit any Prettier changes with a `[skip-package]` tag to prevent recursive workflow triggers, or skip commit if no changes are needed

## Implementation Details

- Uses `actions/setup-node@v4` with Node.js 20
- Runs `npx --yes prettier --write .` to format all files
- Configures git user as "JEFF-bot" for automated commits
- Includes conditional logic to only push if formatting changes were made
- Uses `[skip-package]` commit message suffix to prevent the workflow from re-triggering on the formatting commit itself

This ensures code formatting consistency across the repository and aligns with the project's Prettier configuration (as referenced in CLAUDE.md).

https://claude.ai/code/session_01SxAk24pJoNX7BCK72E7iPw