### PR TITLE
ci: upgrade actions/checkout to v7 and actions/setup-node to v6

### DIFF
--- a/.github/workflows/package-skills.yml
+++ b/.github/workflows/package-skills.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
 


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v6 → v7 (latest)
- Upgrade `actions/setup-node` from v4 → v6 (latest, bundles Node 24)

Both actions now run on Node 24, eliminating the Node 20 deprecation warning seen in CI logs. Dependabot is already configured to track future version bumps once this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxAk24pJoNX7BCK72E7iPw)_