### PR TITLE
Add zoneless change detection requirement to Angular guidelines

### DIFF
--- a/.claude/agents/jeff-agent-angular-code-reviewer.md
+++ b/.claude/agents/jeff-agent-angular-code-reviewer.md
@@ -32,6 +32,7 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 
 - [ ] Using standalone components (not NgModules)
 - [ ] NOT setting `standalone: true` explicitly (default in Angular 20+)
+- [ ] Using zoneless change detection — `provideZonelessChangeDetection()` in `app.config.ts` and `zone.js` absent from `polyfills` in `angular.json`
 - [ ] Using signals for state management
 - [ ] Using `input()` and `output()` functions, not decorators
 - [ ] Using `computed()` for derived state
@@ -129,6 +130,7 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 ### Critical Issues (Must Fix)
 
 - Using deprecated Angular APIs
+- `zone.js` present in `polyfills` in `angular.json`, or `provideZonelessChangeDetection()` missing from `app.config.ts` — project must be zoneless
 - Using `any` type extensively
 - Memory leaks (unsubscribed observables)
 - Security issues (XSS, unsafe bindings)

--- a/.claude/agents/jeff-agent-angular-software-developer.md
+++ b/.claude/agents/jeff-agent-angular-software-developer.md
@@ -27,6 +27,7 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 
 - Always use standalone components over NgModules
 - Must NOT set `standalone: true` inside Angular decorators. It's the default in Angular v20+.
+- Always use zoneless change detection — provide `provideZonelessChangeDetection()` in `app.config.ts` and ensure `zone.js` is NOT in the `polyfills` array in `angular.json`
 - Use signals for state management
 - Implement lazy loading for feature routes
 - Do NOT use the `@HostBinding` and `@HostListener` decorators. Put host bindings inside the `host` object of the `@Component` or `@Directive` decorator instead

--- a/.claude/skills/jeff-skill-angular-project/SKILL.md
+++ b/.claude/skills/jeff-skill-angular-project/SKILL.md
@@ -20,9 +20,11 @@ Before proceeding:
 1. Run `npm install -g @angular/cli` to install or update to the latest Angular CLI globally.
    - In the update scenario, run `ng update @angular/core @angular/cli` as well
 2. Verify installation by running `ng version` and ensure the Angular CLI version is the latest available version.
-3. Create a new project by running `ng new <project-name>` and follow the prompts to set up the project with the desired configuration.
+3. Create a new project by running `ng new <project-name> --zoneless` and follow the prompts to set up the project with the desired configuration.
    - Use `CSS` for stylesheet format
    - Do NOT enable server side rendering
+   - The `--zoneless` flag configures the project without `zone.js`, enabling zoneless change detection
+   - If adding zoneless to an existing project instead, update `app.config.ts` to use `provideZonelessChangeDetection()` and remove `zone.js` from the `polyfills` array in `angular.json`
 4. Use the latest stable version of `tailwindcss` as a `devDependency`. Refer to the documentation at https://tailwindcss.com/docs.
    - To install run `ng add tailwindcss` and confirm any prompts. This is equivalent to doing the following (just here for your reference in case something goes wrong or needs to be fixed):
      - `npm install -D tailwindcss @tailwindcss/postcss postcss`


### PR DESCRIPTION
## Summary

Updates Angular project setup guidelines and code review/development standards to mandate zoneless change detection across all new Angular projects.

## Key Changes

- **SKILL.md**: Updated project creation instructions to include the `--zoneless` flag when running `ng new`, with additional guidance for retrofitting zoneless change detection to existing projects via `app.config.ts` and `angular.json` modifications
- **jeff-agent-angular-code-reviewer.md**: Added zoneless change detection to the standards checklist and marked missing `provideZonelessChangeDetection()` or presence of `zone.js` in polyfills as a critical issue requiring fixes
- **jeff-agent-angular-software-developer.md**: Added explicit requirement to always use zoneless change detection with clear instructions on implementation

## Implementation Details

The changes establish zoneless change detection as a mandatory standard by:
1. Making it the default for new projects via the `--zoneless` CLI flag
2. Providing clear migration path for existing projects (update `app.config.ts` and remove `zone.js` from `polyfills`)
3. Integrating the requirement into both code review and development agent guidelines as a non-negotiable standard
4. Classifying missing zoneless configuration as a critical issue in code reviews

https://claude.ai/code/session_01RP1XKG2pRkuBFxP1RtE2vW