### PR TITLE
Expand Prettier skill with monorepo & Angular config patterns

### DIFF
--- a/.claude/agents/jeff-agent-tailwind-code-reviewer.md
+++ b/.claude/agents/jeff-agent-tailwind-code-reviewer.md
@@ -5,6 +5,7 @@ skills:
   - jeff-skill-tailwind-design-system
   - jeff-skill-angular-project
   - jeff-skill-angular-aws-cognito
+  - jeff-skill-install-prettier
 ---
 
 ## Startup Acknowledgment

--- a/.claude/agents/jeff-agent-tailwind-software-developer.md
+++ b/.claude/agents/jeff-agent-tailwind-software-developer.md
@@ -5,6 +5,7 @@ skills:
   - jeff-skill-tailwind-design-system
   - jeff-skill-angular-project
   - jeff-skill-angular-aws-cognito
+  - jeff-skill-install-prettier
 ---
 
 ## Startup Acknowledgment

--- a/.claude/skills/jeff-skill-install-prettier/SKILL.md
+++ b/.claude/skills/jeff-skill-install-prettier/SKILL.md
@@ -1,53 +1,151 @@
 ---
 name: jeff-skill-install-prettier
-description: Install prettier. Use when setting up a dev environment, fixing TypeScript and JavaScript formatting issues, or asked to "install prettier", "configure prettier", or "set up code formatting".
+description: Install and configure Prettier for JavaScript/TypeScript projects. Use when setting up a dev environment, fixing formatting issues, or asked to "install prettier", "configure prettier", or "set up code formatting".
 ---
 
 Before proceeding, ensure nvm (Node Version Manager) and Node.js are installed using the `jeff-skill-install-nodejs` skill.
 
-1. Create `.prettierrc.json` in the project root if it doesn't already exist.
-2. The content of `.prettierrc.json` should at a minimum contain every setting listed below (do not remove any existing setting just ensure these settings all exist and if not add them):
-   ```json
-   {
-     "printWidth": 120,
-     "singleQuote": true,
-     "semi": true,
-     "tabWidth": 2,
-     "trailingComma": "none",
-     "endOfLine": "lf"
-   }
-   ```
-3. Create `.prettierignore` in the project root if it doesn't already exist.
-4. The content of `.prettierignore` should at a minimum contain every setting listed below (do not remove any existing setting just ensure these settings all exist and if not add them):
-   ```
-   node_modules
-   dist
-   build
-   coverage
-   ```
-5. If a `package.json` file exists in the project root, ensure `prettier:fix` and `prettier:check` are listed as `scripts` command, and if these commands don't exist add them.
-   ```json
-    "scripts":{
-      "prettier:fix": "npx prettier --write .",
-      "prettier:check": "npx prettier --check ."
-    }
-   ```
-6. If a `package.json` file does NOT exist in the project root, create or append to a `Makefile` with prettier commands:
-   - If `Makefile` already exists, append the prettier targets to it (only if they don't already exist)
-   - If `Makefile` doesn't exist, create it with the prettier targets
+## Universal Config Rules
 
-   ```makefile
-   .PHONY: prettier-fix prettier-check
+These six formatting options are a fixed fingerprint — apply them exactly in every project and sub-package. Never change, omit, or add to them without explicit instruction:
 
-   prettier-fix:
-   	npx prettier --write .
+```json
+{
+  "printWidth": 120,
+  "singleQuote": true,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "endOfLine": "lf"
+}
+```
 
-   prettier-check:
-   	npx prettier --check .
-   ```
+## Config File Format by Context
 
-7. There is no reason to have prettier configuration or dependency (outside of the two `prettier:fix` and `prettier:check` script commands in package.json, or the prettier targets in Makefile) in `package.json` or any other file. If extra prettier configuration exists in `package.json` or any other file, remove it to avoid confusion and ensure all configuration is in `.prettierrc.json` and `.prettierignore`. This also applies to "nested" `package.json` files in subdirectories (for example projects that have a `client` or `cdk` directory).
+- **Root-level, CDK/infra packages, backend packages**: use `.prettierrc.json`
+- **Angular client sub-packages** (inside a monorepo `client/` or `apps/web/` directory): use `.prettierrc.yaml`
 
-## Additional resources
+`.prettierrc.yaml` format:
 
-- Refer to the Prettier documentation if you need help: https://prettier.io/docs/
+```yaml
+printWidth: 120
+singleQuote: true
+semi: true
+tabWidth: 2
+trailingComma: 'none'
+endOfLine: 'lf'
+```
+
+**Sub-packages never extend or reference a parent config.** Each package that has its own config duplicates the full rule set verbatim.
+
+## Prettier Version
+
+Add prettier as a dev dependency using version `^3.8.4`:
+
+```bash
+npm install --save-dev prettier@^3.8.4
+```
+
+## npm Scripts
+
+Every `package.json` that uses prettier defines exactly these two scripts. Use `prettier` directly (not `npx prettier`):
+
+```json
+{
+  "scripts": {
+    "prettier:check": "prettier --check .",
+    "prettier:fix": "prettier --write ."
+  }
+}
+```
+
+## Makefile (non-JS projects only)
+
+If no `package.json` exists in the project root, create or append these targets to a `Makefile`:
+
+```makefile
+.PHONY: prettier-fix prettier-check
+
+prettier-fix:
+	npx prettier --write .
+
+prettier-check:
+	npx prettier --check .
+```
+
+## .prettierignore Patterns by Context
+
+### Single-package Angular project (one `.prettierignore` at root)
+
+```
+node_modules
+/dist/*
+build
+coverage
+src/index.html
+*.js
+*.gitkeep
+*.ico
+*.png
+public/site.webmanifest
+```
+
+Also add `scripts/update-csp-hash.js` if that file exists in the project.
+
+### Angular client sub-package (inside a monorepo)
+
+Same as single-package Angular above — applied within the sub-package directory.
+
+### Root monorepo `.prettierignore` (covers everything not caught by sub-package ignores)
+
+```
+node_modules
+dist
+build
+coverage
+client/src/index.html
+```
+
+Also add `client/scripts/update-csp-hash.js` if that file exists. Replace `client/` with the actual client directory name (e.g. `apps/web/`).
+
+### CDK / infra package
+
+```
+node_modules/
+dist/
+cdk.out/
+*.js
+```
+
+### Backend-only root (no separate client/infra sub-packages)
+
+```
+node_modules
+dist
+cdk.out
+build
+coverage
+*.js
+*.d.ts
+```
+
+## What NOT to Do
+
+- Do not add prettier config under a `"prettier"` key in `package.json`
+- Do not create `prettier.config.js` or `prettier.config.ts`
+- Do not add prettier to `dependencies` (only `devDependencies`)
+- Do not put additional prettier config in sub-package `package.json` files beyond the two scripts
+- Do not have sub-package configs inherit or extend a parent config
+
+If extra prettier configuration exists in `package.json` or any other non-standard location, remove it and consolidate everything into `.prettierrc.json` / `.prettierrc.yaml` and `.prettierignore`.
+
+## Key Notes
+
+- `src/index.html` is always excluded for Angular projects — it is framework-generated
+- `*.js` in TypeScript projects means compiled output — always exclude it
+- `cdk.out/` must be in CDK/infra `.prettierignore` — it contains synthesized CloudFormation
+- `scripts/update-csp-hash.js` appears in Angular ignore lists whenever a CSP hash update script is present
+
+## Additional Resources
+
+- Prettier documentation: https://prettier.io/docs/

--- a/.claude/skills/jeff-skill-install-prettier/SKILL.md
+++ b/.claude/skills/jeff-skill-install-prettier/SKILL.md
@@ -40,10 +40,10 @@ endOfLine: 'lf'
 
 ## Prettier Version
 
-Add prettier as a dev dependency using version `^3.8.4`:
+Add prettier as a dev dependency at the latest stable version:
 
 ```bash
-npm install --save-dev prettier@^3.8.4
+npm install --save-dev prettier@latest
 ```
 
 ## npm Scripts

--- a/plugins/jeff-plugin-tailwind/skills/jeff-skill-install-prettier
+++ b/plugins/jeff-plugin-tailwind/skills/jeff-skill-install-prettier
@@ -1,0 +1,1 @@
+../../../.claude/skills/jeff-skill-install-prettier


### PR DESCRIPTION
## Summary

Significantly expanded the `jeff-skill-install-prettier` skill documentation to provide comprehensive, context-aware Prettier configuration guidance for diverse project structures (single-package, monorepos, Angular, CDK/infra, backend-only). Added the skill to both Tailwind agents and created a plugin symlink for discoverability.

## Key Changes

- **Restructured SKILL.md** with clear sections for universal config rules, context-specific file formats (`.prettierrc.json` vs `.prettierrc.yaml`), and ignore patterns
- **Added monorepo support**: documented separate `.prettierignore` patterns for root, Angular client sub-packages, and CDK/infra packages
- **Angular-specific guidance**: included `src/index.html`, `*.js`, and CSP hash script exclusions; clarified `.prettierrc.yaml` format for client sub-packages
- **Clarified npm scripts**: changed from `npx prettier` to direct `prettier` command (assumes dev dependency installed)
- **Added explicit "What NOT to Do" section**: prevents common misconfigurations (inline `package.json` config, `.js` config files, etc.)
- **Added Prettier version guidance**: `npm install --save-dev prettier@latest`
- **Added skill to agents**: registered `jeff-skill-install-prettier` in both `jeff-agent-tailwind-code-reviewer` and `jeff-agent-tailwind-software-developer`
- **Created plugin symlink**: added `plugins/jeff-plugin-tailwind/skills/jeff-skill-install-prettier` → canonical skill location

## Implementation Details

- Config rules remain fixed (printWidth: 120, singleQuote, semi, tabWidth: 2, trailingComma: none, endOfLine: lf)
- Sub-packages in monorepos duplicate full rule sets verbatim rather than extending parent configs
- Ignore patterns vary by context (Angular projects exclude compiled `.js` and `src/index.html`; CDK projects exclude `cdk.out/`)
- Documentation now covers single-package, monorepo root, Angular sub-package, CDK/infra, and backend-only scenarios

https://claude.ai/code/session_01WCwqraQhYcLsVJQCmyUr1n