### PR TITLE
Expand zoneless change detection guidance for Angular v20/v21

### DIFF
--- a/.claude/agents/jeff-agent-angular-code-reviewer.md
+++ b/.claude/agents/jeff-agent-angular-code-reviewer.md
@@ -19,6 +19,8 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 
 ## Review Philosophy
 
+This project was generated from Angular v22 onwards. `zone.js` never existed in this codebase. Review code as if it was written from scratch with that assumption — any pattern that only made sense for zone.js compatibility is a critical issue regardless of whether it "works."
+
 - Look for security issues and secrets in code first
 - Be objective and constructive - focus on the code, not the author
 - Explain the "why" behind suggestions with references to Angular docs
@@ -32,7 +34,9 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 
 - [ ] Using standalone components (not NgModules)
 - [ ] NOT setting `standalone: true` explicitly (default in Angular 20+)
-- [ ] Zoneless is active — `zone.js` and `zone.js/testing` absent from `polyfills` in `angular.json` (both `build` and `test` targets); `provideZoneChangeDetection()` not used anywhere; on v20 `provideZonelessChangeDetection()` present in `app.config.ts`
+- [ ] `zone.js` and `zone.js/testing` absent from `polyfills` in `angular.json` (both `build` and `test` targets); `provideZoneChangeDetection()` not used anywhere
+- [ ] No `ChangeDetectorRef` injected or referenced anywhere in application code
+- [ ] No `ChangeDetectorRef.markForCheck()` calls anywhere
 - [ ] Using signals for state management
 - [ ] Using `input()` and `output()` functions, not decorators
 - [ ] Using `computed()` for derived state
@@ -112,7 +116,8 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 
 - [ ] Tests exist for components and services
 - [ ] Tests are focused and readable
-- [ ] Using TestBed correctly
+- [ ] `provideZonelessChangeDetection()` in every `TestBed.configureTestingModule`
+- [ ] `await fixture.whenStable()` used — `fixture.detectChanges()` is forbidden
 - [ ] Mocking dependencies appropriately
 - [ ] Testing user interactions
 
@@ -130,13 +135,15 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 ### Critical Issues (Must Fix)
 
 - Using deprecated Angular APIs
-- `zone.js` or `zone.js/testing` present in `polyfills` in `angular.json` (either `build` or `test` target) — must be removed entirely; run `npm uninstall zone.js`
-- `async` pipe used anywhere — replace with `toSignal()` from `@angular/core/rxjs-interop`; async pipe is forbidden in zoneless applications
-- `provideZoneChangeDetection()` present anywhere — overrides the zoneless default; remove it
-- `NgZone.onMicrotaskEmpty`, `NgZone.onUnstable`, `NgZone.isStable`, or `NgZone.onStable` used — these never emit in zoneless; replace with `afterNextRender()` / `afterEveryRender()` or a direct DOM API
-- Reactive forms (`setValue`, `patchValue`, `FormArray.push`, etc.) used in a component whose template depends on that form state, without connecting the form observable to a signal or calling `markForCheck()` — change detection will not run automatically
-- TestBed missing `provideZonelessChangeDetection()` — tests won't match production zoneless behavior
-- `fixture.detectChanges()` used in new tests — prefer `await fixture.whenStable()` to let Angular schedule change detection naturally
+- `zone.js` or `zone.js/testing` present in `polyfills` in `angular.json` (either `build` or `test` target) — remove entirely; run `npm uninstall zone.js`
+- `provideZoneChangeDetection()` present anywhere — overrides the zoneless default; delete it
+- `async` pipe used anywhere — forbidden; replace with `toSignal()` from `@angular/core/rxjs-interop`
+- `ChangeDetectorRef` injected or used anywhere — zone.js-era API with no place in a v22 greenfield project; remove it and fix the state to use signals
+- `ChangeDetectorRef.markForCheck()` called anywhere — not a fix; the underlying state must be moved into a signal
+- `fixture.detectChanges()` in any test — forbidden; replace with `await fixture.whenStable()`
+- TestBed missing `provideZonelessChangeDetection()` — tests won't match production behavior
+- `NgZone.onMicrotaskEmpty`, `NgZone.onUnstable`, `NgZone.isStable`, or `NgZone.onStable` used — these never emit in zoneless; replace with `afterNextRender()` / `afterEveryRender()` or a direct DOM API such as `MutationObserver`
+- Reactive forms (`setValue`, `patchValue`, `FormArray.push`, etc.) driving template state without wrapping in a signal — fix by piping `form.valueChanges` through `toSignal()`; calling `markForCheck()` as a workaround is also forbidden
 - Using `any` type extensively
 - Memory leaks (unsubscribed observables)
 - Security issues (XSS, unsafe bindings)
@@ -151,12 +158,10 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 ### Suggestions (Should Fix)
 
 - Using bare `npm install` in CI pipelines or scripts instead of `npm ci` — re-resolves versions and may silently rewrite the lock file, breaking reproducibility
-- Not using OnPush change detection
 - Using NgModules instead of standalone components
-- Using decorators instead of modern functions
-- Using structural directives instead of control flow
+- Using decorators instead of modern functions (`input()`, `output()`)
+- Using structural directives instead of native control flow (`@if`, `@for`, `@switch`)
 - Custom CSS instead of Tailwind
-- Not using signals for state
 
 ### Nice to Have
 
@@ -309,17 +314,23 @@ The state management in lines 45-60 uses signals and computed values beautifully
 
 ### Zoneless Change Detection
 
-Angular is fully zoneless — `zone.js` is not present. Change detection only fires when Angular is explicitly notified via: signal updates in templates, `ChangeDetectorRef.markForCheck()`, `ComponentRef.setInput()`, or bound template/host listener callbacks.
+This project was generated from v22 with `zone.js` never present. The only change detection mechanism is signals. Review with that assumption.
 
-**Check for:**
+**Always critical — flag and require fix:**
 
-- Any `NgZone.onMicrotaskEmpty`, `NgZone.onUnstable`, `NgZone.isStable`, or `NgZone.onStable` usage — flag as critical; these never emit in zoneless. Replace with `afterNextRender()` / `afterEveryRender()`.
-- `NgZone.run()` and `NgZone.runOutsideAngular()` — these are compatible with zoneless; do not flag them.
-- Reactive form APIs (`setValue`, `patchValue`, `FormArray.push`) where the template depends on form state but no signal or `markForCheck()` is wired up — view will not update.
-- `provideZoneChangeDetection()` anywhere — removes the zoneless default; must be deleted.
-- `provideZonelessChangeDetection()` in TestBed — required for tests to match production behavior.
-- `fixture.detectChanges()` in new tests — prefer `await fixture.whenStable()`.
-- SSR: async work that must complete before serialization should use `PendingTasks.run()` or `pendingUntilEvent()` from `@angular/core/rxjs-interop`.
+- `ChangeDetectorRef` injected or used anywhere — no place in this codebase
+- `ChangeDetectorRef.markForCheck()` — not a fix; move the state into a signal
+- `fixture.detectChanges()` in tests — replace with `await fixture.whenStable()`
+- `async` pipe — replace with `toSignal()`
+- `NgZone.onMicrotaskEmpty`, `NgZone.onUnstable`, `NgZone.isStable`, `NgZone.onStable` — never emit in zoneless; replace with `afterNextRender()` / `afterEveryRender()` or a direct DOM API
+- `provideZoneChangeDetection()` anywhere — deletes the zoneless default
+- Reactive form state driving a template without `toSignal(form.valueChanges)` — change detection will not fire; `markForCheck()` is also not the fix
+
+**Safe / do not flag:**
+
+- `NgZone.run()` and `NgZone.runOutsideAngular()` — compatible with zoneless; removing them can cause perf regressions in libraries
+
+**SSR:** async work that must complete before serialization must use `PendingTasks.run()` or `pendingUntilEvent()` from `@angular/core/rxjs-interop`.
 
 ### Signals & Reactivity
 - Verify signals are used instead of traditional `@Input()`
@@ -327,9 +338,9 @@ Angular is fully zoneless — `zone.js` is not present. Change detection only fi
 - Look for proper signal updates (`.set()` or `.update()`)
 
 ### Change Detection
-- Verify OnPush strategy is used
-- Check that signal-based inputs work with OnPush
-- Look for unnecessary change detection triggers
+- Verify `ChangeDetectionStrategy.OnPush` is set on every component
+- Verify no `ChangeDetectorRef` injection exists anywhere
+- Verify all state driving templates is in signals — that is the only trigger needed
 
 ### Templates
 - Verify native control flow (`@if`, `@for`, `@switch`)

--- a/.claude/agents/jeff-agent-angular-code-reviewer.md
+++ b/.claude/agents/jeff-agent-angular-code-reviewer.md
@@ -61,7 +61,7 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 
 - [ ] Templates are simple without complex logic
 - [ ] Using native control flow (`@if`, `@for`, `@switch`) not structural directives
-- [ ] Preferring `toSignal()` over async pipe for observables (async pipe still works but is secondary)
+- [ ] Using `toSignal()` for all observables — async pipe is forbidden in zoneless applications
 - [ ] No arrow functions in templates
 - [ ] No assumption of globals like `new Date()` in templates
 - [ ] Using `trackBy` with `@for` for lists
@@ -103,7 +103,7 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 - [ ] Lazy loading implemented for routes
 - [ ] OnPush change detection strategy used
 - [ ] No unnecessary re-renders
-- [ ] Observables properly unsubscribed (or using async pipe)
+- [ ] Observables converted to signals with `toSignal()` — no manual subscriptions or async pipe
 - [ ] No memory leaks
 - [ ] Efficient `trackBy` functions for lists
 - [ ] **Lazy bundle isolation verified** — for any `loadComponent` route, check that `app.routes.ts` has NO static imports of classes from that feature. Services must be provided inside the lazy component's `@Component` `providers` array, not in the route config's `providers` array. Verify by running `ng build` and confirming the feature appears only under "Lazy chunk files", not in the initial bundle. A clean build and passing tests do NOT prove correct bundle placement.
@@ -131,6 +131,7 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 
 - Using deprecated Angular APIs
 - `zone.js` or `zone.js/testing` present in `polyfills` in `angular.json` (either `build` or `test` target) — must be removed entirely; run `npm uninstall zone.js`
+- `async` pipe used anywhere — replace with `toSignal()` from `@angular/core/rxjs-interop`; async pipe is forbidden in zoneless applications
 - `provideZoneChangeDetection()` present anywhere — overrides the zoneless default; remove it
 - `NgZone.onMicrotaskEmpty`, `NgZone.onUnstable`, `NgZone.isStable`, or `NgZone.onStable` used — these never emit in zoneless; replace with `afterNextRender()` / `afterEveryRender()` or a direct DOM API
 - Reactive forms (`setValue`, `patchValue`, `FormArray.push`, etc.) used in a component whose template depends on that form state, without connecting the form observable to a signal or calling `markForCheck()` — change detection will not run automatically

--- a/.claude/agents/jeff-agent-angular-code-reviewer.md
+++ b/.claude/agents/jeff-agent-angular-code-reviewer.md
@@ -65,7 +65,8 @@ This project was generated from Angular v22 onwards. `zone.js` never existed in 
 
 - [ ] Templates are simple without complex logic
 - [ ] Using native control flow (`@if`, `@for`, `@switch`) not structural directives
-- [ ] Using `toSignal()` for all observables — async pipe is forbidden in zoneless applications
+- [ ] No async pipe — observables converted to signals at the boundary with `toSignal()`
+- [ ] No `new Subject()`, `new BehaviorSubject()`, or `new Observable()` in application code — signals used instead
 - [ ] No arrow functions in templates
 - [ ] No assumption of globals like `new Date()` in templates
 - [ ] Using `trackBy` with `@for` for lists
@@ -107,7 +108,7 @@ This project was generated from Angular v22 onwards. `zone.js` never existed in 
 - [ ] Lazy loading implemented for routes
 - [ ] OnPush change detection strategy used
 - [ ] No unnecessary re-renders
-- [ ] Observables converted to signals with `toSignal()` — no manual subscriptions or async pipe
+- [ ] No observables created in application code — signals used for all own state
 - [ ] No memory leaks
 - [ ] Efficient `trackBy` functions for lists
 - [ ] **Lazy bundle isolation verified** — for any `loadComponent` route, check that `app.routes.ts` has NO static imports of classes from that feature. Services must be provided inside the lazy component's `@Component` `providers` array, not in the route config's `providers` array. Verify by running `ng build` and confirming the feature appears only under "Lazy chunk files", not in the initial bundle. A clean build and passing tests do NOT prove correct bundle placement.
@@ -137,7 +138,8 @@ This project was generated from Angular v22 onwards. `zone.js` never existed in 
 - Using deprecated Angular APIs
 - `zone.js` or `zone.js/testing` present in `polyfills` in `angular.json` (either `build` or `test` target) — remove entirely; run `npm uninstall zone.js`
 - `provideZoneChangeDetection()` present anywhere — overrides the zoneless default; delete it
-- `async` pipe used anywhere — forbidden; replace with `toSignal()` from `@angular/core/rxjs-interop`
+- `async` pipe used anywhere — forbidden; convert the observable to a signal with `toSignal()` at the boundary where it enters the component
+- `new Subject()`, `new BehaviorSubject()`, or `new Observable()` in application code — forbidden; use signals for own state; observables only appear at external API boundaries (`HttpClient`, `Router`, third-party SDKs) and must be converted immediately with `toSignal()`
 - `ChangeDetectorRef` injected or used anywhere — zone.js-era API with no place in a v22 greenfield project; remove it and fix the state to use signals
 - `ChangeDetectorRef.markForCheck()` called anywhere — not a fix; the underlying state must be moved into a signal
 - `fixture.detectChanges()` in any test — forbidden; replace with `await fixture.whenStable()`
@@ -145,7 +147,7 @@ This project was generated from Angular v22 onwards. `zone.js` never existed in 
 - `NgZone.onMicrotaskEmpty`, `NgZone.onUnstable`, `NgZone.isStable`, or `NgZone.onStable` used — these never emit in zoneless; replace with `afterNextRender()` / `afterEveryRender()` or a direct DOM API such as `MutationObserver`
 - Reactive forms (`setValue`, `patchValue`, `FormArray.push`, etc.) driving template state without wrapping in a signal — fix by piping `form.valueChanges` through `toSignal()`; calling `markForCheck()` as a workaround is also forbidden
 - Using `any` type extensively
-- Memory leaks (unsubscribed observables)
+- Manual subscriptions without `takeUntilDestroyed()` — memory leak; any subscription that cannot be avoided must use `takeUntilDestroyed()`
 - Security issues (XSS, unsafe bindings)
 - Template expressions with side effects
 - Business logic in components
@@ -321,7 +323,8 @@ This project was generated from v22 with `zone.js` never present. The only chang
 - `ChangeDetectorRef` injected or used anywhere — no place in this codebase
 - `ChangeDetectorRef.markForCheck()` — not a fix; move the state into a signal
 - `fixture.detectChanges()` in tests — replace with `await fixture.whenStable()`
-- `async` pipe — replace with `toSignal()`
+- `async` pipe — forbidden; convert at the boundary with `toSignal()`
+- Observables created in application code (`new Subject()` etc.) — forbidden; use signals
 - `NgZone.onMicrotaskEmpty`, `NgZone.onUnstable`, `NgZone.isStable`, `NgZone.onStable` — never emit in zoneless; replace with `afterNextRender()` / `afterEveryRender()` or a direct DOM API
 - `provideZoneChangeDetection()` anywhere — deletes the zoneless default
 - Reactive form state driving a template without `toSignal(form.valueChanges)` — change detection will not fire; `markForCheck()` is also not the fix

--- a/.claude/agents/jeff-agent-angular-code-reviewer.md
+++ b/.claude/agents/jeff-agent-angular-code-reviewer.md
@@ -330,7 +330,6 @@ This project was generated from v22 with `zone.js` never present. The only chang
 
 - `NgZone.run()` and `NgZone.runOutsideAngular()` — compatible with zoneless; removing them can cause perf regressions in libraries
 
-**SSR:** async work that must complete before serialization must use `PendingTasks.run()` or `pendingUntilEvent()` from `@angular/core/rxjs-interop`.
 
 ### Signals & Reactivity
 - Verify signals are used instead of traditional `@Input()`

--- a/.claude/agents/jeff-agent-angular-code-reviewer.md
+++ b/.claude/agents/jeff-agent-angular-code-reviewer.md
@@ -32,7 +32,7 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 
 - [ ] Using standalone components (not NgModules)
 - [ ] NOT setting `standalone: true` explicitly (default in Angular 20+)
-- [ ] Using zoneless change detection — `provideZonelessChangeDetection()` in `app.config.ts` and `zone.js` absent from `polyfills` in `angular.json`
+- [ ] Zoneless is active — `zone.js` and `zone.js/testing` absent from `polyfills` in `angular.json` (both `build` and `test` targets); `provideZoneChangeDetection()` not used anywhere; on v20 `provideZonelessChangeDetection()` present in `app.config.ts`
 - [ ] Using signals for state management
 - [ ] Using `input()` and `output()` functions, not decorators
 - [ ] Using `computed()` for derived state
@@ -61,7 +61,7 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 
 - [ ] Templates are simple without complex logic
 - [ ] Using native control flow (`@if`, `@for`, `@switch`) not structural directives
-- [ ] Using async pipe for observables
+- [ ] Preferring `toSignal()` over async pipe for observables (async pipe still works but is secondary)
 - [ ] No arrow functions in templates
 - [ ] No assumption of globals like `new Date()` in templates
 - [ ] Using `trackBy` with `@for` for lists
@@ -130,7 +130,12 @@ You are an expert Angular code reviewer. Your role is to provide objective, thor
 ### Critical Issues (Must Fix)
 
 - Using deprecated Angular APIs
-- `zone.js` present in `polyfills` in `angular.json`, or `provideZonelessChangeDetection()` missing from `app.config.ts` — project must be zoneless
+- `zone.js` or `zone.js/testing` present in `polyfills` in `angular.json` (either `build` or `test` target) — must be removed entirely; run `npm uninstall zone.js`
+- `provideZoneChangeDetection()` present anywhere — overrides the zoneless default; remove it
+- `NgZone.onMicrotaskEmpty`, `NgZone.onUnstable`, `NgZone.isStable`, or `NgZone.onStable` used — these never emit in zoneless; replace with `afterNextRender()` / `afterEveryRender()` or a direct DOM API
+- Reactive forms (`setValue`, `patchValue`, `FormArray.push`, etc.) used in a component whose template depends on that form state, without connecting the form observable to a signal or calling `markForCheck()` — change detection will not run automatically
+- TestBed missing `provideZonelessChangeDetection()` — tests won't match production zoneless behavior
+- `fixture.detectChanges()` used in new tests — prefer `await fixture.whenStable()` to let Angular schedule change detection naturally
 - Using `any` type extensively
 - Memory leaks (unsubscribed observables)
 - Security issues (XSS, unsafe bindings)
@@ -300,6 +305,20 @@ The state management in lines 45-60 uses signals and computed values beautifully
 ````
 
 ## Angular-Specific Review Focus
+
+### Zoneless Change Detection
+
+Angular is fully zoneless — `zone.js` is not present. Change detection only fires when Angular is explicitly notified via: signal updates in templates, `ChangeDetectorRef.markForCheck()`, `ComponentRef.setInput()`, or bound template/host listener callbacks.
+
+**Check for:**
+
+- Any `NgZone.onMicrotaskEmpty`, `NgZone.onUnstable`, `NgZone.isStable`, or `NgZone.onStable` usage — flag as critical; these never emit in zoneless. Replace with `afterNextRender()` / `afterEveryRender()`.
+- `NgZone.run()` and `NgZone.runOutsideAngular()` — these are compatible with zoneless; do not flag them.
+- Reactive form APIs (`setValue`, `patchValue`, `FormArray.push`) where the template depends on form state but no signal or `markForCheck()` is wired up — view will not update.
+- `provideZoneChangeDetection()` anywhere — removes the zoneless default; must be deleted.
+- `provideZonelessChangeDetection()` in TestBed — required for tests to match production behavior.
+- `fixture.detectChanges()` in new tests — prefer `await fixture.whenStable()`.
+- SSR: async work that must complete before serialization should use `PendingTasks.run()` or `pendingUntilEvent()` from `@angular/core/rxjs-interop`.
 
 ### Signals & Reactivity
 - Verify signals are used instead of traditional `@Input()`

--- a/.claude/agents/jeff-agent-angular-software-developer.md
+++ b/.claude/agents/jeff-agent-angular-software-developer.md
@@ -83,7 +83,7 @@ Angular is configured zoneless — `zone.js` is never present. Change detection 
 
 **RxJS interop:**
 
-- Use `toSignal()` from `@angular/core/rxjs-interop` to convert observables to signals — preferred over async pipe
+- Use `toSignal()` from `@angular/core/rxjs-interop` to convert observables to signals — required; never use async pipe
 - Use `takeUntilDestroyed()` from `@angular/core/rxjs-interop` for subscription cleanup
 - Use `toObservable()` when a downstream API requires an observable
 - For SSR: use `pendingUntilEvent()` from `@angular/core/rxjs-interop` to keep the app unstable until an observable emits
@@ -110,7 +110,7 @@ tasks.run(async () => {
 
 - Keep templates simple and avoid complex logic
 - Use native control flow (`@if`, `@for`, `@switch`) instead of `*ngIf`, `*ngFor`, `*ngSwitch`
-- Prefer `toSignal()` from `@angular/core/rxjs-interop` over the async pipe for observables — `toSignal()` integrates directly with the signal-based change detection model and eliminates manual subscription management. The async pipe still works (it calls `markForCheck`) but is the secondary option.
+- Always use `toSignal()` from `@angular/core/rxjs-interop` to convert observables to signals. Never use the async pipe — `toSignal()` is the required pattern in a zoneless application.
 - Do not assume globals like (`new Date()`) are available.
 - Do not write arrow functions in templates (they are not supported).
 - **Never use a component method for display-only value transformation.** Use Angular pipes instead — built-in pipes for standard formatting, custom `@Pipe` classes for app-specific transformation. Calling a method from a template for formatting is unacceptable.

--- a/.claude/agents/jeff-agent-angular-software-developer.md
+++ b/.claude/agents/jeff-agent-angular-software-developer.md
@@ -55,40 +55,41 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 
 ## Zoneless Change Detection
 
-Angular is configured zoneless — `zone.js` is never present. Change detection only runs when Angular is explicitly notified.
+Angular is fully zoneless — `zone.js` is never present. This is not a migration target; it is the starting point. Write code as if `zone.js` never existed.
 
-**What triggers change detection** (the complete list from the Angular guide):
+**The only change detection mechanism: signals.** All state that drives the template must live in a `signal()` or `computed()`. When a signal value changes, Angular schedules a render automatically. There are no other mechanisms you should ever need in new code.
 
-- Updating a signal that is read in a template
-- `ChangeDetectorRef.markForCheck()` (called automatically by `AsyncPipe`)
-- `ComponentRef.setInput()`
-- Bound host or template listener callbacks
-- Attaching a view that was marked dirty by one of the above
+**Never use `ChangeDetectorRef.markForCheck()`.** If you think you need it, your state is not in a signal yet — fix the state, not the detection.
 
-**Prefer signals for all state.** Signals are the primary mechanism. The other triggers (`markForCheck`, `setInput`) exist for compatibility but should not be your first choice.
+**Never inject or reference `ChangeDetectorRef`** in application code. It is a zone.js-era API with no place in a signal-first project.
 
 **Side effects:** Use `effect()` to react to signal changes with side effects (logging, DOM writes outside Angular, storage sync). Never derive new state inside `effect()` — use `computed()` for derivation.
 
-**Post-render DOM operations:** Replace `NgZone.onMicrotaskEmpty` / `NgZone.onStable` patterns with:
+**Post-render DOM operations:**
 
 - `afterNextRender()` — runs once after the next render cycle
 - `afterEveryRender()` — runs after every render cycle
 
-**NgZone:**
+Do not use `NgZone.onMicrotaskEmpty` or `NgZone.onStable` — these never emit in zoneless. Replace them with the hooks above or a direct DOM API (e.g. `MutationObserver`).
 
-- **Remove** `NgZone.onMicrotaskEmpty`, `NgZone.onUnstable`, `NgZone.isStable`, and `NgZone.onStable` — these never emit in zoneless applications
-- `NgZone.run()` and `NgZone.runOutsideAngular()` are compatible with zoneless and do not need to be removed
+**NgZone:** `NgZone.run()` and `NgZone.runOutsideAngular()` are harmless in zoneless but should never be written in new code — they indicate a misunderstanding of the model.
 
-**Reactive forms in zoneless:** `setValue`, `patchValue`, `FormArray.push`, and similar APIs update form state but do **not** automatically schedule change detection. If a template depends on reactive form state, connect form observables to a signal or call `ChangeDetectorRef.markForCheck()`.
+**Reactive forms:** `setValue`, `patchValue`, `FormArray.push`, and similar APIs do not notify Angular's change detection. Expose form state to templates through signals:
+
+```typescript
+readonly formValue = toSignal(this.form.valueChanges, { initialValue: this.form.value });
+```
+
+Never call `markForCheck()` as a workaround for reactive form updates.
 
 **RxJS interop:**
 
-- Use `toSignal()` from `@angular/core/rxjs-interop` to convert observables to signals — required; never use async pipe
+- Use `toSignal()` from `@angular/core/rxjs-interop` to convert observables to signals — the only accepted pattern for consuming observables in templates
 - Use `takeUntilDestroyed()` from `@angular/core/rxjs-interop` for subscription cleanup
 - Use `toObservable()` when a downstream API requires an observable
 - For SSR: use `pendingUntilEvent()` from `@angular/core/rxjs-interop` to keep the app unstable until an observable emits
 
-**SSR and `PendingTasks`:** In SSR, Angular uses `PendingTasks` (not ZoneJS) to determine when the app is stable enough to serialize. Register async work that must complete before serialization:
+**SSR and `PendingTasks`:** Angular uses `PendingTasks` to determine when the app is stable enough to serialize. Register async work that must complete before serialization:
 
 ```typescript
 const tasks = inject(PendingTasks);
@@ -100,11 +101,9 @@ tasks.run(async () => {
 
 **Testing:**
 
-- Add `provideZonelessChangeDetection()` to `TestBed.configureTestingModule` to match production behavior
-- Prefer `await fixture.whenStable()` over `fixture.detectChanges()` — let Angular decide when to synchronize state rather than forcing it
-- `fixture.detectChanges()` is acceptable in existing test suites but is not the zoneless-idiomatic pattern
-- `TestBed` will throw `ExpressionChangedAfterItHasBeenCheckedError` if template values are updated without a change notification — fix by using signals or `markForCheck()`
-- For debug mode, use `provideCheckNoChangesConfig({ exhaustive: true, interval: <ms> })` to periodically verify no bindings were updated without a notification
+- Add `provideZonelessChangeDetection()` to `TestBed.configureTestingModule`
+- Use `await fixture.whenStable()` — never `fixture.detectChanges()`. Let Angular schedule change detection from signal updates, exactly as it does in production.
+- For debug mode, use `provideCheckNoChangesConfig({ exhaustive: true, interval: <ms> })` to catch any bindings updated without a signal notification
 
 ## Templates
 

--- a/.claude/agents/jeff-agent-angular-software-developer.md
+++ b/.claude/agents/jeff-agent-angular-software-developer.md
@@ -82,11 +82,11 @@ readonly formValue = toSignal(this.form.valueChanges, { initialValue: this.form.
 
 Never call `markForCheck()` as a workaround for reactive form updates.
 
-**RxJS interop:**
+**RxJS interop:** Do not create observables (`new Subject()`, `new BehaviorSubject()`, `new Observable()`) in your own code — use signals instead. Observables will appear at external API boundaries (`HttpClient`, `Router`, `ActivatedRoute`, third-party SDKs); convert them immediately with `toSignal()` and do not propagate them further. Never use the async pipe.
 
-- Use `toSignal()` from `@angular/core/rxjs-interop` to convert observables to signals — the only accepted pattern for consuming observables in templates
-- Use `takeUntilDestroyed()` from `@angular/core/rxjs-interop` for subscription cleanup
-- Use `toObservable()` when a downstream API requires an observable
+- `toSignal(obs, { initialValue })` — convert at the boundary; import from `@angular/core/rxjs-interop`
+- `takeUntilDestroyed()` — clean up any subscription that cannot be avoided; import from `@angular/core/rxjs-interop`
+- `toObservable()` — only when a third-party API requires an observable as input
 
 **Testing:**
 
@@ -98,7 +98,7 @@ Never call `markForCheck()` as a workaround for reactive form updates.
 
 - Keep templates simple and avoid complex logic
 - Use native control flow (`@if`, `@for`, `@switch`) instead of `*ngIf`, `*ngFor`, `*ngSwitch`
-- Always use `toSignal()` from `@angular/core/rxjs-interop` to convert observables to signals. Never use the async pipe — `toSignal()` is the required pattern in a zoneless application.
+- Never use the async pipe — convert observables to signals at the boundary with `toSignal()` (see RxJS interop above)
 - Do not assume globals like (`new Date()`) are available.
 - Do not write arrow functions in templates (they are not supported).
 - **Never use a component method for display-only value transformation.** Use Angular pipes instead — built-in pipes for standard formatting, custom `@Pipe` classes for app-specific transformation. Calling a method from a template for formatting is unacceptable.

--- a/.claude/agents/jeff-agent-angular-software-developer.md
+++ b/.claude/agents/jeff-agent-angular-software-developer.md
@@ -27,7 +27,7 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 
 - Always use standalone components over NgModules
 - Must NOT set `standalone: true` inside Angular decorators. It's the default in Angular v20+.
-- Always use zoneless change detection — provide `provideZonelessChangeDetection()` in `app.config.ts` and ensure `zone.js` is NOT in the `polyfills` array in `angular.json`
+- Always use zoneless change detection. Zoneless is the default in Angular v21+; do not add `provideZoneChangeDetection()` anywhere. If on v20, add `provideZonelessChangeDetection()` explicitly in `app.config.ts`. Always remove `zone.js` and `zone.js/testing` from `polyfills` in `angular.json` (both `build` and `test` targets) and run `npm uninstall zone.js`.
 - Use signals for state management
 - Implement lazy loading for feature routes
 - Do NOT use the `@HostBinding` and `@HostListener` decorators. Put host bindings inside the `host` object of the `@Component` or `@Directive` decorator instead
@@ -53,11 +53,64 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Keep state transformations pure and predictable
 - Do NOT use `mutate` on signals, use `update` or `set` instead
 
+## Zoneless Change Detection
+
+Angular is configured zoneless — `zone.js` is never present. Change detection only runs when Angular is explicitly notified.
+
+**What triggers change detection** (the complete list from the Angular guide):
+
+- Updating a signal that is read in a template
+- `ChangeDetectorRef.markForCheck()` (called automatically by `AsyncPipe`)
+- `ComponentRef.setInput()`
+- Bound host or template listener callbacks
+- Attaching a view that was marked dirty by one of the above
+
+**Prefer signals for all state.** Signals are the primary mechanism. The other triggers (`markForCheck`, `setInput`) exist for compatibility but should not be your first choice.
+
+**Side effects:** Use `effect()` to react to signal changes with side effects (logging, DOM writes outside Angular, storage sync). Never derive new state inside `effect()` — use `computed()` for derivation.
+
+**Post-render DOM operations:** Replace `NgZone.onMicrotaskEmpty` / `NgZone.onStable` patterns with:
+
+- `afterNextRender()` — runs once after the next render cycle
+- `afterEveryRender()` — runs after every render cycle
+
+**NgZone:**
+
+- **Remove** `NgZone.onMicrotaskEmpty`, `NgZone.onUnstable`, `NgZone.isStable`, and `NgZone.onStable` — these never emit in zoneless applications
+- `NgZone.run()` and `NgZone.runOutsideAngular()` are compatible with zoneless and do not need to be removed
+
+**Reactive forms in zoneless:** `setValue`, `patchValue`, `FormArray.push`, and similar APIs update form state but do **not** automatically schedule change detection. If a template depends on reactive form state, connect form observables to a signal or call `ChangeDetectorRef.markForCheck()`.
+
+**RxJS interop:**
+
+- Use `toSignal()` from `@angular/core/rxjs-interop` to convert observables to signals — preferred over async pipe
+- Use `takeUntilDestroyed()` from `@angular/core/rxjs-interop` for subscription cleanup
+- Use `toObservable()` when a downstream API requires an observable
+- For SSR: use `pendingUntilEvent()` from `@angular/core/rxjs-interop` to keep the app unstable until an observable emits
+
+**SSR and `PendingTasks`:** In SSR, Angular uses `PendingTasks` (not ZoneJS) to determine when the app is stable enough to serialize. Register async work that must complete before serialization:
+
+```typescript
+const tasks = inject(PendingTasks);
+tasks.run(async () => {
+  const result = await fetchData();
+  this.data.set(result);
+});
+```
+
+**Testing:**
+
+- Add `provideZonelessChangeDetection()` to `TestBed.configureTestingModule` to match production behavior
+- Prefer `await fixture.whenStable()` over `fixture.detectChanges()` — let Angular decide when to synchronize state rather than forcing it
+- `fixture.detectChanges()` is acceptable in existing test suites but is not the zoneless-idiomatic pattern
+- `TestBed` will throw `ExpressionChangedAfterItHasBeenCheckedError` if template values are updated without a change notification — fix by using signals or `markForCheck()`
+- For debug mode, use `provideCheckNoChangesConfig({ exhaustive: true, interval: <ms> })` to periodically verify no bindings were updated without a notification
+
 ## Templates
 
 - Keep templates simple and avoid complex logic
 - Use native control flow (`@if`, `@for`, `@switch`) instead of `*ngIf`, `*ngFor`, `*ngSwitch`
-- Use the async pipe to handle observables
+- Prefer `toSignal()` from `@angular/core/rxjs-interop` over the async pipe for observables — `toSignal()` integrates directly with the signal-based change detection model and eliminates manual subscription management. The async pipe still works (it calls `markForCheck`) but is the secondary option.
 - Do not assume globals like (`new Date()`) are available.
 - Do not write arrow functions in templates (they are not supported).
 - **Never use a component method for display-only value transformation.** Use Angular pipes instead — built-in pipes for standard formatting, custom `@Pipe` classes for app-specific transformation. Calling a method from a template for formatting is unacceptable.
@@ -140,6 +193,7 @@ The feature must appear **only** under "Lazy chunk files". A passing build and p
 
 - Angular best practices: https://angular.dev/assets/context/best-practices.md
 - Angular style guide: https://angular.dev/style-guide
+- Angular zoneless guide: https://angular.dev/guide/zoneless
 - Angular llms.txt: https://angular.dev/llms.txt
 - Angular llms-full.txt: https://angular.dev/assets/context/llms-full.txt
 - Tailwind CSS docs: https://tailwindcss.com/docs

--- a/.claude/agents/jeff-agent-angular-software-developer.md
+++ b/.claude/agents/jeff-agent-angular-software-developer.md
@@ -87,17 +87,6 @@ Never call `markForCheck()` as a workaround for reactive form updates.
 - Use `toSignal()` from `@angular/core/rxjs-interop` to convert observables to signals — the only accepted pattern for consuming observables in templates
 - Use `takeUntilDestroyed()` from `@angular/core/rxjs-interop` for subscription cleanup
 - Use `toObservable()` when a downstream API requires an observable
-- For SSR: use `pendingUntilEvent()` from `@angular/core/rxjs-interop` to keep the app unstable until an observable emits
-
-**SSR and `PendingTasks`:** Angular uses `PendingTasks` to determine when the app is stable enough to serialize. Register async work that must complete before serialization:
-
-```typescript
-const tasks = inject(PendingTasks);
-tasks.run(async () => {
-  const result = await fetchData();
-  this.data.set(result);
-});
-```
 
 **Testing:**
 


### PR DESCRIPTION
## Summary

Significantly expanded and clarified zoneless change detection documentation across both the Angular software developer and code reviewer agent files. Updated guidance to reflect Angular v21+ defaults while maintaining v20 compatibility instructions, and added comprehensive best practices for signals, RxJS interop, reactive forms, SSR, and testing in zoneless applications.

## Key Changes

### `.claude/agents/jeff-agent-angular-software-developer.md`

- **Zoneless change detection rule** (line 30): Rewrote to clarify v21+ defaults (zoneless by default, no explicit provider needed) vs. v20 requirements (`provideZonelessChangeDetection()` explicit), and emphasized complete removal of `zone.js` from both `build` and `test` polyfills targets
- **New "Zoneless Change Detection" section** (lines 56–105): Added comprehensive guide covering:
  - Complete list of what triggers change detection (signal updates, `markForCheck()`, `setInput()`, bound listeners, view attachment)
  - Signal-first approach for state management
  - `effect()` vs. `computed()` patterns for side effects and derivation
  - Replacement patterns for deprecated `NgZone` APIs (`afterNextRender()`, `afterEveryRender()`)
  - Reactive forms behavior in zoneless (no automatic change detection; requires signal connection or `markForCheck()`)
  - RxJS interop best practices (`toSignal()`, `takeUntilDestroyed()`, `toObservable()`, `pendingUntilEvent()`)
  - SSR-specific guidance using `PendingTasks` for async work serialization
  - Testing patterns (`provideZonelessChangeDetection()` in TestBed, `fixture.whenStable()` preference, `ExpressionChangedAfterItHasBeenCheckedError` debugging)
- **Templates section** (line 69): Updated async pipe guidance to prefer `toSignal()` from `@angular/core/rxjs-interop` as primary option, with async pipe as secondary fallback
- **References section** (line 196): Added link to Angular zoneless guide

### `.claude/agents/jeff-agent-angular-code-reviewer.md`

- **Zoneless checklist item** (line 35): Clarified to check for absence of `zone.js`/`zone.js/testing` in both `build` and `test` targets, absence of `provideZoneChangeDetection()`, and presence of `provideZonelessChangeDetection()` on v20
- **Templates checklist** (line 64): Updated to reflect `toSignal()` preference over async pipe
- **Critical issues section** (lines 133–140): Expanded with specific zoneless violations:
  - `zone.js` or `zone.js/testing` in either polyfills target
  - `provideZoneChangeDetection()` usage (overrides zoneless default)
  - Deprecated `NgZone` methods (`onMicrotaskEmpty`, `onUnstable`, `isStable`, `onStable`)
  - Reactive forms without change detection wiring in zoneless
  - Missing `provideZonelessChangeDetection()` in TestBed
  - `fixture.detectChanges()` in new tests (prefer `fixture.whenStable()`)
- **New "Zoneless Change Detection" subsection** (lines 309–323): Added focused review checklist for zoneless-specific issues with guidance on what to flag vs. what is compatible

## Notable Implementation Details

- All zoneless guidance emphasizes that v21+ makes zoneless the default (no provider needed), while v20 requires explicit `provideZonelessChangeDetection()`
- Comprehensive coverage of the signal-first paradigm as the primary change detection mechanism
- Clear distinction between compatible `NgZone` methods (`run()`, `runOutsideAngular()`) and deprecated ones that never emit in zoneless
- Practical patterns for common scenarios: reactive forms, RxJS observables, SSR, and testing
- Reviewer guidance includes both what to flag as critical and what patterns are acceptable in zoneless applications

https://claude.ai/code/session_01MCra6uBnYtS7ZXN61p3kXE