### PR TITLE
Document monorepo prettier setup and root Makefile pattern

### DIFF
--- a/.claude/skills/jeff-skill-install-prettier/SKILL.md
+++ b/.claude/skills/jeff-skill-install-prettier/SKILL.md
@@ -92,6 +92,8 @@ prettier-check:
 	npx prettier --check .
 ```
 
+Replace `apps/web/` with the actual client sub-package directory (e.g. `client/`, `client/src/`). Add or remove lines for each sub-package that owns its own prettier config.
+
 Add `prettier` and `prettier-check` to the `.PHONY` declaration.
 
 **Always run `make prettier` (not `npx prettier --write .` directly) when formatting the whole monorepo.** Running prettier from the root without the Makefile target skips sub-package formatting.

--- a/.claude/skills/jeff-skill-install-prettier/SKILL.md
+++ b/.claude/skills/jeff-skill-install-prettier/SKILL.md
@@ -130,6 +130,7 @@ node_modules
 dist
 build
 coverage
+client/src/index.html
 apps/web/
 infra/
 ```

--- a/.claude/skills/jeff-skill-install-prettier/SKILL.md
+++ b/.claude/skills/jeff-skill-install-prettier/SKILL.md
@@ -73,6 +73,29 @@ prettier-check:
 	npx prettier --check .
 ```
 
+## Monorepo Root Makefile
+
+In a monorepo where sub-packages own their own prettier config, the root `Makefile` must have `prettier` and `prettier-check` targets that:
+
+1. Delegate to each sub-package that owns its own prettier (via its `npm run prettier:fix` / `npm run prettier:check` script)
+2. Run the root prettier last (covering everything the sub-packages exclude)
+
+```makefile
+prettier:
+	cd apps/web && npm run prettier:fix
+	cd infra && npm run prettier:fix
+	npx prettier --write .
+
+prettier-check:
+	cd apps/web && npm run prettier:check
+	cd infra && npm run prettier:check
+	npx prettier --check .
+```
+
+Add `prettier` and `prettier-check` to the `.PHONY` declaration.
+
+**Always run `make prettier` (not `npx prettier --write .` directly) when formatting the whole monorepo.** Running prettier from the root without the Makefile target skips sub-package formatting.
+
 ## .prettierignore Patterns by Context
 
 ### Single-package Angular project (one `.prettierignore` at root)
@@ -96,17 +119,20 @@ Also add `scripts/update-csp-hash.js` if that file exists in the project.
 
 Same as single-package Angular above — applied within the sub-package directory.
 
-### Root monorepo `.prettierignore` (covers everything not caught by sub-package ignores)
+### Root monorepo `.prettierignore`
+
+The root `.prettierignore` must **exclude the entire directory** of every sub-package that owns its own prettier config. This prevents the root prettier from touching files those sub-packages manage themselves:
 
 ```
 node_modules
 dist
 build
 coverage
-client/src/index.html
+apps/web/
+infra/
 ```
 
-Also add `client/scripts/update-csp-hash.js` if that file exists. Replace `client/` with the actual client directory name (e.g. `apps/web/`).
+Replace `apps/web/` and `infra/` with the actual sub-package directories. Do **not** list individual file exclusions from sub-packages here — exclude the whole directory instead.
 
 ### CDK / infra package
 
@@ -136,5 +162,6 @@ coverage
 - Do not add prettier to `dependencies` (only `devDependencies`)
 - Do not put additional prettier config in sub-package `package.json` files beyond the two scripts
 - Do not have sub-package configs inherit or extend a parent config
+- Do not run `npx prettier --write .` from the monorepo root directly — always use `make prettier`
 
 If extra prettier configuration exists in `package.json` or any other non-standard location, remove it and consolidate everything into `.prettierrc.json` / `.prettierrc.yaml` and `.prettierignore`.

--- a/.claude/skills/jeff-skill-install-prettier/SKILL.md
+++ b/.claude/skills/jeff-skill-install-prettier/SKILL.md
@@ -132,7 +132,7 @@ apps/web/
 infra/
 ```
 
-Replace `apps/web/` and `infra/` with the actual sub-package directories. Do **not** list individual file exclusions from sub-packages here — exclude the whole directory instead.
+Replace `apps/web/` and `infra/` with the actual sub-package directories (e.g. `client/`, `client/src/`). Do **not** list individual file exclusions from sub-packages here — exclude the whole directory instead.
 
 ### CDK / infra package
 


### PR DESCRIPTION
## Summary

Expanded the `jeff-skill-install-prettier` skill documentation to cover monorepo-specific prettier configuration patterns, including root Makefile delegation and `.prettierignore` best practices.

## Key Changes

- **Added "Monorepo Root Makefile" section** documenting how to structure `prettier` and `prettier-check` targets that delegate to sub-packages before running root prettier
- **Clarified root `.prettierignore` strategy** — exclude entire sub-package directories (not individual files) to prevent root prettier from touching files managed by sub-packages
- **Added critical warning** to always use `make prettier` instead of running `npx prettier --write .` directly from monorepo root, with explanation of why
- **Updated "Do Not" section** with explicit guidance against running prettier directly from monorepo root
- **Refined sub-package `.prettierignore` documentation** to emphasize whole-directory exclusions over file-level patterns

## Implementation Details

The documentation now provides a complete example of a monorepo prettier setup where:
1. Sub-packages (e.g., `apps/web/`, `infra/`) own their own prettier config and scripts
2. Root Makefile coordinates formatting by running sub-package scripts first, then root prettier
3. Root `.prettierignore` excludes entire sub-package directories to avoid conflicts
4. Users are explicitly warned against bypassing the Makefile pattern

This prevents common monorepo issues where root prettier overwrites or conflicts with sub-package formatting.

https://claude.ai/code/session_018kzFwREC2s3Qa6YZHbzz62