### PR TITLE
Document Makefile build target pattern for monorepos

### DIFF
--- a/.claude/skills/jeff-skill-install-prettier/SKILL.md
+++ b/.claude/skills/jeff-skill-install-prettier/SKILL.md
@@ -136,6 +136,7 @@ dist
 build
 coverage
 client/src/index.html
+client/src/index.html
 apps/web/
 infra/
 ```

--- a/.claude/skills/jeff-skill-install-prettier/SKILL.md
+++ b/.claude/skills/jeff-skill-install-prettier/SKILL.md
@@ -80,6 +80,8 @@ In a monorepo where sub-packages own their own prettier config, the root `Makefi
 1. Delegate to each sub-package that owns its own prettier (via its `npm run prettier:fix` / `npm run prettier:check` script)
 2. Run the root prettier last (covering everything the sub-packages exclude)
 
+Each sub-package that has a buildable output (e.g. an Angular app) must also have a dedicated `build-<name>` target using `$(MAKE) -C <dir> build` — **never** `cd <dir> && make build`. This keeps the pattern consistent with other subproject targets and allows root-level build checks without entering subdirectories.
+
 ```makefile
 prettier:
 	cd apps/web && npm run prettier:fix
@@ -90,13 +92,16 @@ prettier-check:
 	cd apps/web && npm run prettier:check
 	cd infra && npm run prettier:check
 	npx prettier --check .
+
+build-web:
+	$(MAKE) -C apps/web build
 ```
 
-Replace `apps/web/` with the actual client sub-package directory (e.g. `client/`, `client/src/`). Add or remove lines for each sub-package that owns its own prettier config.
-
-Add `prettier` and `prettier-check` to the `.PHONY` declaration.
+Add `prettier`, `prettier-check`, and `build-web` (and any other build targets) to the `.PHONY` declaration.
 
 **Always run `make prettier` (not `npx prettier --write .` directly) when formatting the whole monorepo.** Running prettier from the root without the Makefile target skips sub-package formatting.
+
+**Always run `make build-web` (not `cd apps/web && make build`) for pre-commit build checks.** All subproject operations must go through root Makefile targets.
 
 ## .prettierignore Patterns by Context
 
@@ -130,12 +135,11 @@ node_modules
 dist
 build
 coverage
-client/src/index.html
 apps/web/
 infra/
 ```
 
-Replace `apps/web/` and `infra/` with the actual sub-package directories (e.g. `client/`, `client/src/`). Do **not** list individual file exclusions from sub-packages here — exclude the whole directory instead.
+Replace `apps/web/` and `infra/` with the actual sub-package directories. Do **not** list individual file exclusions from sub-packages here — exclude the whole directory instead.
 
 ### CDK / infra package
 

--- a/.claude/skills/jeff-skill-install-prettier/SKILL.md
+++ b/.claude/skills/jeff-skill-install-prettier/SKILL.md
@@ -139,7 +139,7 @@ apps/web/
 infra/
 ```
 
-Replace `apps/web/` and `infra/` with the actual sub-package directories. Do **not** list individual file exclusions from sub-packages here — exclude the whole directory instead.
+Replace `apps/web/` and `infra/` with the actual sub-package directories (e.g. `client/`, `client/src/`). Do **not** list individual file exclusions from sub-packages here — exclude the whole directory instead.
 
 ### CDK / infra package
 

--- a/.claude/skills/jeff-skill-install-prettier/SKILL.md
+++ b/.claude/skills/jeff-skill-install-prettier/SKILL.md
@@ -136,7 +136,6 @@ dist
 build
 coverage
 client/src/index.html
-client/src/index.html
 apps/web/
 infra/
 ```

--- a/.claude/skills/jeff-skill-install-prettier/SKILL.md
+++ b/.claude/skills/jeff-skill-install-prettier/SKILL.md
@@ -135,6 +135,7 @@ node_modules
 dist
 build
 coverage
+client/src/index.html
 apps/web/
 infra/
 ```


### PR DESCRIPTION
## Summary

Updated the `jeff-skill-install-prettier` documentation to establish a consistent pattern for build targets in monorepo Makefiles, ensuring all subproject operations go through root-level targets rather than direct subdirectory invocations.

## Key Changes

- **Added build target pattern guidance**: Documented that each sub-package with buildable output must have a dedicated `build-<name>` target using `$(MAKE) -C <dir> build` syntax (never `cd <dir> && make build`)
- **Updated Makefile example**: Added a `build-web` target example to the monorepo prettier configuration section
- **Clarified `.PHONY` declaration**: Updated instructions to include build targets in the `.PHONY` declaration alongside prettier targets
- **Added enforcement note**: Included a new callout emphasizing that all subproject operations must go through root Makefile targets for consistency and to enable root-level build checks without entering subdirectories
- **Simplified documentation**: Removed redundant file path examples and clarified that whole directories should be excluded in `.prettierignore` rather than individual files

## Implementation Details

The changes reinforce the principle that monorepo Makefiles should provide a single entry point for all operations. This pattern:
- Keeps the Makefile interface consistent across all subproject targets
- Enables pre-commit build checks to run from the root without changing directories
- Maintains clarity about which targets are available at the root level

https://claude.ai/code/session_01DvMgCYMf5wTy3CZ3ofDJbN