### PR TITLE
Replace frontend plugin with tailwind plugin in README

### DIFF
--- a/README
+++ b/README
@@ -17,7 +17,7 @@ To install or use the plugins:
 /plugin install jeff-plugin-aws-solution-architect@jeff-plugins
 /plugin install jeff-plugin-golang@jeff-plugins
 /plugin install jeff-plugin-ansible@jeff-plugins
-/plugin install jeff-plugin-frontend@jeff-plugins
+/plugin install jeff-plugin-tailwind@jeff-plugins
 /plugin install jeff-plugin-shell-bash@jeff-plugins
 /plugin install jeff-plugin-phaser@jeff-plugins
 /plugin install jeff-plugin-project@jeff-plugins


### PR DESCRIPTION
## Summary
Updated the plugin installation instructions in README to replace `jeff-plugin-frontend` with `jeff-plugin-tailwind`.

## Changes
- Updated `/plugin install jeff-plugin-frontend@jeff-plugins` to `/plugin install jeff-plugin-tailwind@jeff-plugins` in the plugin installation list

## Notes
This appears to be a documentation update reflecting a change in available plugins. Ensure that `jeff-plugin-tailwind` has been properly created and registered in `.claude-plugin/marketplace.json` before merging, per the repo conventions.

https://claude.ai/code/session_01WK3r4q7B4uTkgVyWXUEq3T