### PR TITLE
docs: add prettier-ignore usage guidelines to skill

### DIFF
--- a/.claude/skills/jeff-skill-install-prettier/SKILL.md
+++ b/.claude/skills/jeff-skill-install-prettier/SKILL.md
@@ -173,3 +173,13 @@ coverage
 - Do not run `npx prettier --write .` from the monorepo root directly — always use `make prettier`
 
 If extra prettier configuration exists in `package.json` or any other non-standard location, remove it and consolidate everything into `.prettierrc.json` / `.prettierrc.yaml` and `.prettierignore`.
+
+## `<!-- prettier-ignore -->` Is a Last Resort
+
+Never add a `<!-- prettier-ignore -->` (or `// prettier-ignore` / `# prettier-ignore`) comment to silence a formatting failure. First try, in order:
+
+1. Reformat the offending block by hand so Prettier's own output is acceptable.
+2. Adjust the file's config (`.prettierrc.json` / `.prettierrc.yaml`) if the universal fingerprint genuinely doesn't fit the file type.
+3. Exclude the specific file or directory via `.prettierignore` if it shouldn't be formatted at all.
+
+Only reach for an inline `prettier-ignore` directive after all three of the above are exhausted and there is no other path forward — e.g. hand-aligned ASCII tables or output that must preserve exact whitespace for a downstream tool. Treat every use as exceptional: state in a PR description or nearby comment why none of the alternatives worked.


### PR DESCRIPTION
## Summary

Added comprehensive guidance to the `jeff-skill-install-prettier` skill documentation on when and how to use Prettier ignore directives as a last resort.

## Changes

- Added new section `<!-- prettier-ignore --> Is a Last Resort` to `SKILL.md`
- Documented a three-step escalation path before using inline ignore directives:
  1. Reformat the offending block by hand
  2. Adjust file-specific Prettier config if needed
  3. Exclude via `.prettierignore` if the file shouldn't be formatted
- Clarified that inline `prettier-ignore` comments should only be used in exceptional cases (e.g., hand-aligned ASCII tables, whitespace-sensitive output)
- Added requirement to document the rationale in PR descriptions or nearby comments when ignore directives are used

## Rationale

This guidance prevents overuse of ignore directives and encourages developers to exhaust proper configuration and exclusion mechanisms first, keeping the codebase consistently formatted and maintainable.

https://claude.ai/code/session_014LEobnTRLqw7cw5tYST3g2