### PR TITLE
Add DynamoDB GSI design standards to agent guides

### DIFF
--- a/.claude/agents/jeff-agent-aws-infrastructure-reviewer.md
+++ b/.claude/agents/jeff-agent-aws-infrastructure-reviewer.md
@@ -91,6 +91,13 @@ Every event source, queue, and async invocation must have an explicit, small ret
 - [ ] **Dead-letter queues exist** for every async path: DynamoDB stream `onFailure`, SQS `deadLetterQueue`, EventBridge `deadLetterQueue`
 - [ ] **CDK infra tests assert the retry limit** for every event source mapping (`MaximumRetryAttempts` in CloudFormation)
 
+### 12b. DynamoDB GSI Design
+
+- [ ] For every proposed/reviewed GSI, the write path of each key attribute has been traced (create, update, delete-marking, batch writes)
+- [ ] Attributes that are unconditionally present/maintained on every write use a plain GSI — no synthetic sparse marker attribute introduced without justification
+- [ ] Sparse GSIs (conditionally-present key attributes) are only used when the underlying business condition is genuinely conditional, with that condition stated explicitly
+- [ ] The design output documents the trace: each key attribute paired with a one-line justification for plain vs. sparse
+
 ### 6. Scalability
 
 - [ ] Architecture can scale horizontally
@@ -159,6 +166,7 @@ Every event source, queue, and async invocation must have an explicit, small ret
 - CloudWatch LogGroups without retention, or retention longer than 5 days
 - Resources missing `removalPolicy: RemovalPolicy.DESTROY`
 - `while True:` loops in Lambda handler code (use `for` loops with a configurable max, default 1000)
+- Proposing or accepting a sparse GSI without first tracing the write path of every key attribute — flag as: state whether each attribute is unconditionally maintained (→ plain GSI) or genuinely conditional (→ sparse GSI), a plain GSI on an always-maintained attribute is simpler and needs no extra write-path code
 
 ### Suggestions (Should Fix)
 

--- a/.claude/agents/jeff-agent-aws-solution-architect.md
+++ b/.claude/agents/jeff-agent-aws-solution-architect.md
@@ -146,3 +146,12 @@ When working in CDK or Lambda TypeScript projects:
 ## Lambda Coding Standards
 
 - Never use `while True:` loops in Lambda handlers; always use a `for` loop with a configurable max iteration count (default 1000) to prevent runaway execution and ensure predictable timeouts
+
+## DynamoDB GSI Design Standards
+
+Before proposing any GSI, trace the write path of every attribute in its proposed key. State explicitly whether each key attribute is unconditionally present/maintained on every write (→ plain GSI) or genuinely conditional (→ sparse GSI needed). Never default to a sparse-attribute design without first showing that trace — a plain GSI on an always-maintained attribute is simpler and has no extra write-path code.
+
+- For each attribute in the proposed GSI partition/sort key, walk every write path (create, update, delete-marking, batch writes) that touches the item and confirm whether the attribute is set on that path
+- If the attribute is written unconditionally on every code path that creates or updates the item, use a plain GSI — do not introduce a synthetic sparse marker attribute
+- Only reach for a sparse GSI (an attribute that's conditionally present, e.g. `GSI1PK` set only when `status = 'PENDING'`) when the underlying business condition is genuinely conditional, and state which condition drives its presence/absence
+- Document the trace in the design output: list each key attribute and a one-line justification (e.g. `status` — set in constructor, every `PutItem`/`UpdateItem` includes it → plain GSI)


### PR DESCRIPTION
## Summary

Adds comprehensive DynamoDB Global Secondary Index (GSI) design standards to both the AWS Solution Architect and Infrastructure Reviewer agent guides. These standards establish a clear methodology for evaluating whether a GSI should be plain or sparse based on write-path analysis.

## Changes

- **jeff-agent-aws-solution-architect.md**: Added "DynamoDB GSI Design Standards" section that requires tracing the write path of every proposed GSI key attribute and explicitly documenting whether each attribute is unconditionally maintained (plain GSI) or genuinely conditional (sparse GSI).

- **jeff-agent-aws-infrastructure-reviewer.md**: 
  - Added section 12b "DynamoDB GSI Design" to the review checklist with four specific verification items
  - Added a new anti-pattern flag in the "Red Flags" section to catch sparse GSI proposals without proper write-path justification

## Key Implementation Details

The standards establish a decision framework:
1. **Trace every write path** (create, update, delete-marking, batch writes) for each key attribute
2. **Plain GSI** for attributes unconditionally present/maintained on every write
3. **Sparse GSI** only when the underlying business condition is genuinely conditional
4. **Document the trace** with each key attribute paired to its justification

This prevents over-engineering with sparse GSIs when simpler plain GSIs would suffice, reducing unnecessary write-path complexity.

https://claude.ai/code/session_01VjbuHzyenCuXqfkmgxs81i