### PR TITLE
Add path filters to GitHub Actions workflows for monorepo support

### DIFF
--- a/.claude/skills/jeff-skill-angular-netlify/SKILL.md
+++ b/.claude/skills/jeff-skill-angular-netlify/SKILL.md
@@ -122,6 +122,9 @@ name: deploy-web
 on:
   push:
     branches: [main]
+    paths:
+      - <app-directory>/** # scope to this Angular app so other stacks in the repo (e.g. a golang/ service) don't trigger a deploy
+      - .github/workflows/deploy-web.yml
   workflow_dispatch: # also triggerable ad-hoc from the GitHub Actions UI
 
 concurrency:
@@ -173,7 +176,7 @@ jobs:
           # MY_API_URL: ${{ secrets.MY_API_URL }}
 ```
 
-**Triggers:** Deploys automatically on every merge to `main`, and can also be triggered ad-hoc from the GitHub Actions UI or via `gh workflow run deploy-web`.
+**Triggers:** Deploys automatically on every merge to `main` that touches `<app-directory>/**` (or the workflow file itself), and can also be triggered ad-hoc from the GitHub Actions UI or via `gh workflow run deploy-web`. If `<app-directory>` is the repo root (not a monorepo), drop the `paths:` filter — every change is relevant.
 
 **Why `cancel-in-progress: false`?**
 An in-flight deploy to Netlify should never be interrupted mid-upload. A new deploy queues behind the current one.

--- a/.claude/skills/jeff-skill-golang-project/SKILL.md
+++ b/.claude/skills/jeff-skill-golang-project/SKILL.md
@@ -383,7 +383,9 @@ func TestDivide(t *testing.T) {
 
 ## GitHub Actions
 
-Create `.github/workflows/ci.yml` for continuous integration:
+Create `.github/workflows/ci.yml` for continuous integration.
+
+**Scope triggers to the Go module's directory.** If this module lives at the repo root, omit `paths:` entirely — every change in the repo is relevant. If it shares a monorepo with other stacks (e.g. a `web/` frontend next to a `golang/` service, or `infra/`), scope `paths:` to the module directory so an unrelated change (a README edit, a frontend-only change) doesn't trigger a Go build. Always include the workflow file itself in `paths:` so edits to the CI config are still validated.
 
 ```yaml
 name: jeff-skill-golang-project
@@ -391,8 +393,14 @@ name: jeff-skill-golang-project
 on:
   push:
     branches: [main]
+    paths:
+      - '<module-dir>/**' # e.g. 'golang/**' — omit this whole `paths:` key if the module is at repo root
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - '<module-dir>/**'
+      - '.github/workflows/ci.yml'
 
 jobs:
   test:

--- a/.claude/skills/jeff-skill-python-project/SKILL.md
+++ b/.claude/skills/jeff-skill-python-project/SKILL.md
@@ -207,7 +207,9 @@ def test_example_function_edge_case():
 
 ## GitHub Actions
 
-Create `.github/workflows/ci.yml` for continuous integration:
+Create `.github/workflows/ci.yml` for continuous integration.
+
+**Scope triggers to this project's directory.** If this project lives at the repo root, omit `paths:` entirely — every change in the repo is relevant. If it shares a monorepo with other stacks (e.g. this Python service next to a `web/` frontend or `infra/`), scope `paths:` to the project directory so an unrelated change (a README edit, another service's change) doesn't trigger this build. Always include the workflow file itself in `paths:` so edits to the CI config are still validated.
 
 ```yaml
 name: jeff-skill-python-project
@@ -215,8 +217,14 @@ name: jeff-skill-python-project
 on:
   push:
     branches: [main]
+    paths:
+      - '<project-dir>/**' # e.g. 'infra/**' — omit this whole `paths:` key if the project is at repo root
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - '<project-dir>/**'
+      - '.github/workflows/ci.yml'
 
 jobs:
   test:

--- a/.claude/skills/jeff-skill-typescript-project/SKILL.md
+++ b/.claude/skills/jeff-skill-typescript-project/SKILL.md
@@ -355,7 +355,9 @@ export function add(a: number, b: number): number {
 
 ## GitHub Actions
 
-Create `.github/workflows/ci.yml`:
+Create `.github/workflows/ci.yml`.
+
+**Scope triggers to this project's directory.** If this project lives at the repo root, omit `paths:` entirely — every change in the repo is relevant. If it shares a monorepo with other stacks (e.g. this TypeScript service next to a `golang/` backend or `infra/`), scope `paths:` to the project directory so an unrelated change (a README edit, another service's change) doesn't trigger this build. Always include the workflow file itself in `paths:` so edits to the CI config are still validated.
 
 ```yaml
 name: jeff-skill-typescript-project
@@ -363,8 +365,14 @@ name: jeff-skill-typescript-project
 on:
   push:
     branches: [main]
+    paths:
+      - '<project-dir>/**' # e.g. 'web/**' — omit this whole `paths:` key if the project is at repo root
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - '<project-dir>/**'
+      - '.github/workflows/ci.yml'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Updated GitHub Actions CI/CD workflow documentation across four skill modules to include `paths:` filters that scope triggers to project-specific directories. This prevents unrelated changes in a monorepo from triggering builds and deployments unnecessarily.

## Changes

- **jeff-skill-golang-project**: Added `paths:` configuration to `ci.yml` workflow with guidance on when to omit filters (repo root) vs. scope them (monorepo subdirectory). Includes workflow file itself in trigger paths.

- **jeff-skill-python-project**: Added `paths:` configuration to `ci.yml` workflow with similar monorepo-aware guidance and examples.

- **jeff-skill-typescript-project**: Added `paths:` configuration to `ci.yml` workflow with monorepo scoping and examples.

- **jeff-skill-angular-netlify**: Added `paths:` configuration to `deploy-web.yml` workflow and updated trigger documentation to clarify that deployments only occur on changes to the app directory (or workflow file itself).

## Implementation Details

Each update includes:
- Explicit `paths:` filters under both `push:` and `pull_request:` triggers
- Placeholder syntax (`<module-dir>/**`, `<project-dir>/**`, `<app-directory>/**`) with examples for common monorepo layouts
- Clear guidance that `paths:` should be omitted entirely if the project is at the repo root
- The workflow file itself (`.github/workflows/*.yml`) always included in `paths:` so CI config changes are validated
- Updated trigger descriptions to reflect the new path-scoped behavior

This prevents CI/CD noise in monorepos where multiple independent services/modules coexist (e.g., `golang/` service, `web/` frontend, `infra/` configuration).

https://claude.ai/code/session_01WG8U4fuMQ1y8REEV1yN49a